### PR TITLE
zsh: fix glo not displaying output

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -56,7 +56,7 @@ forgit::inside_work_tree() {
 forgit::log() {
     forgit::inside_work_tree || return 1
     local cmd="echo {} |grep -o '[a-f0-9]\{7\}' |head -1 |xargs -I% git show --color=always % $forgit_emojify $forgit_fancy"
-    eval "git log --graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $@ $forgit_emojify" |
+    git log --graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' "$@" |
         forgit::fzf +s +m --tiebreak=index \
             --bind="enter:execute($cmd |LESS='-R' less)" \
             --bind="ctrl-y:execute-silent(echo {} |grep -o '[a-f0-9]\{7\}' |pbcopy)+abort" \


### PR DESCRIPTION
Might also need to be done in the bash version?

I'm not aware of the rationale in using `eval`, but the [current `eval`ed line](https://github.com/wfxr/forgit/blob/master/forgit.plugin.zsh#L59) does not display any logs for me.

Changing it to also just be `git log --graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' "$@" "$forgit_emojify"` also had issues with git (I've realiased it to `fglo`):

<img width="796" alt="screen shot 2018-08-07 at 10 17 17 am" src="https://user-images.githubusercontent.com/4166642/43763611-77636b64-9a2b-11e8-87b1-43da1ce64747.png">

I do have `emojify` available in my path, and removing the `$forgit_emojify` from that line makes everything work :).