### PR TITLE
Fix multi selection in gitignore generation

### DIFF
--- a/forgit.plugin.sh
+++ b/forgit.plugin.sh
@@ -159,7 +159,9 @@ __forgit_ignore_update() {
 }
 __forgit_ignore_get() {
     mkdir -p $FORGIT_GI_CACHE
-    echo $@ |xargs -I{} bash -c "cat $FORGIT_GI_CACHE/{} 2>/dev/null || (curl -sL https://www.gitignore.io/api/{} |tee $FORGIT_GI_CACHE/{})"
+    for item in "$@"; do
+        cat "$FORGIT_GI_CACHE/$item" 2>/dev/null || (curl -sL https://www.gitignore.io/api/{} |tee "$FORGIT_GI_CACHE/$item")
+    done
 }
 __forgit_ignore_clean() {
     [[ -d $FORGIT_GI_CACHE ]] && rm -rf $FORGIT_GI_CACHE

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -155,7 +155,9 @@ forgit::ignore::update() {
 }
 forgit::ignore::get() {
     mkdir -p $FORGIT_GI_CACHE
-    echo $@ |xargs -I{} bash -c "cat $FORGIT_GI_CACHE/{} 2>/dev/null || (curl -sL https://www.gitignore.io/api/{} |tee $FORGIT_GI_CACHE/{})"
+    for item in "$@"; do
+        cat "$FORGIT_GI_CACHE/$item" 2>/dev/null || (curl -sL https://www.gitignore.io/api/{} |tee "$FORGIT_GI_CACHE/$item")
+    done
 }
 forgit::ignore::clean() {
     setopt localoptions rmstarsilent


### PR DESCRIPTION
Default delimiter in xargs statement is `\n`, so `forgit::ignore::get` doesn't work with multi selection.

Choose for loop as the solution cause:
- `xargs -d` is not available in BSD xargs
- `echo $@ |tr ' ' '\n'` is slower that for loop in this case

```shell
wfxr---forgit  master [!?]                                        8s 16:15:20
❯ forgit::ignore::get() {
    mkdir -p $FORGIT_GI_CACHE
    echo $@ |tr ' ' '\n' |xargs -I{} bash -c "cat $FORGIT_GI_CACHE/{} 2>/dev/null || (curl -sL https://www.gitignore.io/api/{} |tee $FORGIT_GI_CACHE/{})"
}

wfxr---forgit  master [!?]                                           16:15:30
❯ time (forgit::ignore::get macos python)
# omitted
# End of https://www.gitignore.io/api/python
( forgit::ignore::get macos python; )  0.01s user 0.01s system 68% cpu 0.026 total

wfxr---forgit  master [!?]                                           16:17:34
❯ forgit::ignore::get() {
    mkdir -p $FORGIT_GI_CACHE
    for item in "$@"; do
     cat "$FORGIT_GI_CACHE/$item" 2>/dev/null || (curl -sL https://www.gitignore.io/api/{} |tee $FORGIT_GI_CACHE/$item)
    done
}

wfxr---forgit  master [!?]                                           16:17:39
❯ time (forgit::ignore::get macos python)
# omitted
# End of https://www.gitignore.io/api/python
( forgit::ignore::get macos python; )  0.00s user 0.00s system 62% cpu 0.011 total
```