### PR TITLE
Feature: use gitignore templates from local repo directly

### DIFF
--- a/forgit.plugin.sh
+++ b/forgit.plugin.sh
@@ -208,10 +208,16 @@ __forgit_ignore_update() {
     done) | sed 's/.gitignore$//' | sort -f -u >| "$FORGIT_GI_INDEX"
 }
 __forgit_ignore_get() {
+    local item filename header
     for item in "$@"; do
-        echo "### $item"
-        cat "$FORGIT_GI_CACHE/gitignore/templates/${item}.gitignore"
-        echo ""
+        filename=$(find "$FORGIT_GI_CACHE/gitignore/templates" -type f -iname "${item}.gitignore" -print -quit)
+        if [[ -n "$filename" ]]; then
+            header="${filename##*/}" && header="${header%.gitignore}"
+            echo "### $header"
+            cat "$filename"
+            echo ""
+            filename=
+        fi
     done
 }
 fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -202,10 +202,16 @@ forgit::ignore::update() {
     done) | sed 's/.gitignore$//' | sort -f -u >| "$FORGIT_GI_INDEX"
 }
 forgit::ignore::get() {
+    local item filename header
     for item in "$@"; do
-        echo "### $item"
-        cat "$FORGIT_GI_CACHE/gitignore/templates/${item}.gitignore"
-        echo ""
+        filename=$(find "$FORGIT_GI_CACHE/gitignore/templates" -type f -iname "${item}.gitignore" -print -quit)
+        if [[ -n "$filename" ]]; then
+            header="${filename##*/}" && header="${header%.gitignore}"
+            echo "### $header"
+            cat "$filename"
+            echo ""
+            filename=
+        fi
     done
 }
 fi


### PR DESCRIPTION
The gitignore templates used here is from [dvcs/gitignore](https://github.com/dvcs/gitignore), which is
the same one used by [gitignore.io](https://www.gitignore.io/).

Environment variable `FORGIT_GI_USE_LOCAL` is used as a switch to
enable this feature, otherwise the original method is used by default.

`forgit::ignore::update` and `forgit::ignore::get` are rewritten
to download the repo, to get templates from the local repo.
Local variable `preview` in `forgit:ignore` is also rewritten to
get the preview from there.

All these implementations are put into an `if` conditional statement.
If you wanna accept this feature, you'd better reindent the files after merge.
Not only because I didn't indent the content for a better diff view
on purpose, but also the indentations in `forgit.plugin.sh`, the one for BASH,
are **mixed with using two spaces and four spaces**.
