### PR TITLE
Let forgit:ignore mimic the behavior of gitignore.io exactly

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -135,18 +135,23 @@ forgit::ignore::update() {
 forgit::ignore::get() {
     local item filename header stack
     for item in "$@"; do
-        if filename=$(find -L "$FORGIT_GI_SRC" -type f -iname "${item}.gitignore" -print -quit); then
-            [[ -z "$filename" ]] && forgit::warn "No gitignore template found for '$item'." && continue
-            header="${filename##*/}" && header="${header%.gitignore}"
-            echo "### $header ###" && cat "$filename" && echo
+        filename=$(find -L "$FORGIT_GI_SRC" -type f \( -iname "${item}.gitignore" -o -iname "${item}.stack" \) -print -quit)
+        if [[ -z "$filename" ]]; then
+            forgit::warn "No gitignore template found for '$item'." && continue
+        elif [[ "$filename" == *.gitignore ]]; then
+            header="${filename##*/}"; header="${header%.gitignore}"
+            echo "### $header ###"; cat "$filename"; echo
             if [[ -e "${filename%.gitignore}.patch" ]]; then
-                echo "### $header Patch ###" && cat "${filename%.gitignore}.patch" && echo
+                echo "### $header Patch ###"; cat "${filename%.gitignore}.patch"; echo
             else
                 for stack in "${filename%.gitignore}".*.stack; do
-                    header="${stack##*/}" && header="${header%.stack}"
-                    echo "### $header Stack ###" && cat "$stack" && echo
+                    header="${stack##*/}"; header="${header%.stack}"
+                    echo "### $header Stack ###"; cat "$stack"; echo
                 done
             fi
+        else # particularly for Code.stack
+            header="${filename##*/}"; header="${header%.stack}"
+            echo "### $header ###"; cat "$filename"; echo
         fi
     done
 }

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -140,7 +140,7 @@ forgit::ignore::get() {
             header="${filename##*/}" && header="${header%.gitignore}"
             echo "### $header ###" && cat "$filename" && echo
             if [[ -e "${filename%.gitignore}.patch" ]]; then
-                echo "### $header Patch ###" && cat "$filename" && echo
+                echo "### $header Patch ###" && cat "${filename%.gitignore}.patch" && echo
             else
                 for stack in "${filename%.gitignore}".*.stack; do
                     header="${stack##*/}" && header="${header%.stack}"

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -133,7 +133,7 @@ forgit::ignore::update() {
     fi
 }
 forgit::ignore::get() {
-    local item filename header stack
+    local item filename header stack stacks IFS=$'\t\n'
     for item in "$@"; do
         filename=$(find -L "$FORGIT_GI_SRC" -type f \( -iname "${item}.gitignore" -o -iname "${item}.stack" \) -print -quit)
         if [[ -z "$filename" ]]; then
@@ -144,7 +144,8 @@ forgit::ignore::get() {
             if [[ -e "${filename%.gitignore}.patch" ]]; then
                 echo "### $header Patch ###"; cat "${filename%.gitignore}.patch"; echo
             else
-                for stack in "${filename%.gitignore}".*.stack; do
+                stacks=($(command find -L "$FORGIT_GI_SRC" -type f -iname "${item}.*.stack" -print))
+                [[ ${#stacks[@]} -ne 0 ]] && for stack in "${stacks[@]}"; do
                     header="${stack##*/}"; header="${header%.stack}"
                     echo "### $header Stack ###"; cat "$stack"; echo
                 done

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -111,7 +111,7 @@ forgit:ignore() {
     local IFS cmd args cat
     # https://github.com/wfxr/emoji-cli
     hash bat &>/dev/null && cat='bat -l gitignore --color=always --theme=zenburn --style=numbers,grid' || cat="cat"
-    cmd="$cat $FORGIT_GI_SRC/{2}{.gitignore,.patch} 2>/dev/null; $cat $FORGIT_GI_SRC/{2}*.stack 2>/dev/null"
+    cmd="{ $cat $FORGIT_GI_SRC/{2}{.gitignore,.patch}; $cat $FORGIT_GI_SRC/{2}*.stack } 2>/dev/null"
     # shellcheck disable=SC2206,2207
     IFS=$'\n' args=($@) && [[ $# -eq 0 ]] && args=($(forgit::ignore::list | nl -nrn -w4 -s'  ' |
         forgit::fzf -m --preview="$cmd" --preview-window="right:70%" | awk '{print $2}'))


### PR DESCRIPTION
Mimic the behavior of gitignore: matching the corresponding `*.patch`, `*.stack` templates for users automatically.

Because of expansion error of **failglob**, I separate the code `$cat $FORGIT_GI_SRC/{2}*.stack` in line No.114. Otherwise, nothing will be provided for preview.

Generally speaking, there's a `item.gitignore` corresponding to `item.patch` or `item.*.stack`. `Code.stack`, which is symlinked to `VisualStudioCode.gitignore`, is the exception. A special `if` branch is made for it.

Preview of gitignore templates using `cat` doesn't work on commit 09007b. It's fixed on this branch.


