### PR TITLE
Enable configuring preview command for every cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ FORGIT_FZF_DEFAULT_OPTS="
 --height '80%'
 "
 ```
+
+You can also customize options fzf will use for each command individually:
+
+- `ga`: `FORGIT_ADD_FZF_OPTS`
+- `glo`: `FORGIT_LOG_FZF_OPTS`
+- `gi`: `FORGIT_IGNORE_FZF_OPTS`
+- `gd`: `FORGIT_DIFF_FZF_OPTS`
+- `gcf`: `FORGIT_CHECKOUT_FZF_OPTS`
+- `gss`: `FORGIT_STASH_FZF_OPTS`
+- `gclean`: `FORGIT_CLEAN_FZF_OPTS`
+
 ## Optional
 
 - [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy): Improve the `git diff` output.

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -62,7 +62,7 @@ forgit::restore() {
     local cmd files
     files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"|
         forgit::fzf -m -0 --preview="$preview_cmd" |
-        "$FORGIT_RESTORE_FZF_OPTS")"
+        "$FORGIT_CHECKOUT_FZF_OPTS")"
     [[ -n "$files" ]] && echo "$files" |xargs -I{} git checkout {} && git status --short && return
     echo 'Nothing to restore.'
 }
@@ -83,7 +83,7 @@ forgit::clean() {
     forgit::inside_work_tree || return 1
     local files
     # Note: Postfix '/' in directory path should be removed. Otherwise the directory itself will not be removed.
-    files=$(git clean -xdfn "$@"| awk '{print $3}'| forgit::fzf -m -0 |sed 's#/$##')
+    files=$(git clean -xdfn "$@"| awk '{print $3}'| forgit::fzf -m -0 "$FORGIT_CLEAN_FZF_OPTS" |sed 's#/$##')
     [[ -n "$files" ]] && echo "$files" |xargs -I{} git clean -xdf {}
     echo 'Nothing to clean.'
 }

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -19,7 +19,7 @@ forgit::log() {
     fi
     eval "git log --graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $* $forgit_emojify" |
         forgit::fzf +s +m --tiebreak=index \
-            --bind="enter:execute($cmd |LESS='-R' less)" \
+            --bind="enter:execute($preview_cmd |LESS='-R' less)" \
             --bind="ctrl-y:execute-silent(echo {} |grep -o '[a-f0-9]\{7\}' |${FORGIT_COPY_CMD:-pbcopy})" \
             --preview="$preview_cmd"
 }
@@ -37,7 +37,7 @@ forgit::diff() {
     [[ $# -eq 0 ]] && files=$(git rev-parse --show-toplevel)
     git ls-files --modified "$files"|
         forgit::fzf +m -0 \
-            --bind="enter:execute($cmd |LESS='-R' less)" \
+            --bind="enter:execute($preview_cmd |LESS='-R' less)" \
             --preview="$preview_cmd"
 }
 
@@ -74,7 +74,7 @@ forgit::restore() {
     fi
     local cmd files
     files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"|
-        forgit::fzf -m -0 --preview="$cmd")"
+        forgit::fzf -m -0 --preview="$preview_cmd")"
     [[ -n "$files" ]] && echo "$files" |xargs -I{} git checkout {} && git status --short && return
     echo 'Nothing to restore.'
 }
@@ -89,7 +89,7 @@ forgit::stash::show() {
     fi
     git stash list |
         forgit::fzf +s +m -0 --tiebreak=index \
-        --bind="enter:execute($cmd |LESS='-R' less)" \
+        --bind="enter:execute($preview_cmd |LESS='-R' less)" \
         --preview="$preview_cmd"
 }
 
@@ -116,7 +116,7 @@ forgit::ignore() {
     cmd="$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     # shellcheck disable=SC2206,2207
     IFS=$'\n' args=($@) && [[ $# -eq 0 ]] && args=($(forgit::ignore::list | nl -nrn -w4 -s'  ' |
-        forgit::fzf -m --preview="$cmd" --preview-window="right:70%" | awk '{print $2}'))
+        forgit::fzf -m --preview="$preview_cmd" --preview-window="right:70%" | awk '{print $2}'))
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     if hash bat &>/dev/null; then

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -12,33 +12,27 @@ hash emojify &>/dev/null && forgit_emojify='|emojify'
 # git commit viewer
 forgit::log() {
     forgit::inside_work_tree || return 1
-    if [ -z "$FORGIT_LOG_PREVIEW" ]; then
-      local preview_cmd="echo {} |grep -o '[a-f0-9]\{7\}' |head -1 |xargs -I% git show --color=always % $* $forgit_emojify $forgit_fancy"
-    else
-      local preview_cmd="$FORGIT_LOG_PREVIEW"
-    fi
+    local preview_cmd="echo {} |grep -o '[a-f0-9]\{7\}' |head -1 |xargs -I% git show --color=always % $* $forgit_emojify $forgit_fancy"
     eval "git log --graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $* $forgit_emojify" |
         forgit::fzf +s +m --tiebreak=index \
             --bind="enter:execute($preview_cmd |LESS='-R' less)" \
             --bind="ctrl-y:execute-silent(echo {} |grep -o '[a-f0-9]\{7\}' |${FORGIT_COPY_CMD:-pbcopy})" \
-            --preview="$preview_cmd"
+            --preview="$preview_cmd" \
+            "$FORGIT_LOG_FZF_OPTS"
 }
 
 # git diff viewer
 forgit::diff() {
     forgit::inside_work_tree || return 1
-    if [ -z "$FORGIT_DIFF_PREVIEW" ]; then
-      local preview_cmd="git diff --color=always -- {} $forgit_emojify $forgit_fancy"
-    else
-      local preview_cmd="$FORGIT_DIFF_PREVIEW"
-    fi
+    local preview_cmd="git diff --color=always -- {} $forgit_emojify $forgit_fancy"
     local cmd files
     files="$*"
     [[ $# -eq 0 ]] && files=$(git rev-parse --show-toplevel)
     git ls-files --modified "$files"|
         forgit::fzf +m -0 \
             --bind="enter:execute($preview_cmd |LESS='-R' less)" \
-            --preview="$preview_cmd"
+            --preview="$preview_cmd" \
+            "$FORGIT_DIFF_FZF_OPTS"
 }
 
 # git add selector
@@ -50,14 +44,11 @@ forgit::add() {
     untracked=$(git config --get-color color.status.untracked red)
     files=$(git -c color.status=always status --short |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked"|
-    if [ -z "$FORGIT_ADD_PREVIEW" ]; then
-      local preview_cmd="git diff --color=always -- {-1} $forgit_emojify $forgit_fancy"
-    else
-      local preview_cmd="$FORGIT_ADD_PREVIEW"
-    fi
+    local preview_cmd="git diff --color=always -- {-1} $forgit_emojify $forgit_fancy"
         awk '{printf "[%10s]  ", $1; $1=""; print $0}' |
         forgit::fzf -0 -m --nth 2..,.. \
             --preview="$preview_cmd" |
+            "$FORGIT_ADD_FZF_OPTS" |
         cut -d] -f2 |
         sed 's/.* -> //') # for rename case
     [[ -n "$files" ]] && echo "$files" |xargs -I{} git add {} && git status --short && return
@@ -67,14 +58,11 @@ forgit::add() {
 # git checkout-restore selector
 forgit::restore() {
     forgit::inside_work_tree || return 1
-    if [ -z "$FORGIT_RESTORE_PREVIEW" ]; then
-      local preview_cmd="git diff --color=always -- {} $forgit_emojify $forgit_fancy"
-    else
-      local preview_cmd="$FORGIT_RESTORE_PREVIEW"
-    fi
+    local preview_cmd="git diff --color=always -- {} $forgit_emojify $forgit_fancy"
     local cmd files
     files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"|
-        forgit::fzf -m -0 --preview="$preview_cmd")"
+        forgit::fzf -m -0 --preview="$preview_cmd" |
+        "$FORGIT_RESTORE_FZF_OPTS")"
     [[ -n "$files" ]] && echo "$files" |xargs -I{} git checkout {} && git status --short && return
     echo 'Nothing to restore.'
 }
@@ -82,15 +70,12 @@ forgit::restore() {
 # git stash viewer
 forgit::stash::show() {
     forgit::inside_work_tree || return 1
-    if [ -z "$FORGIT_STASH_PREVIEW" ]; then
-      local preview_cmd="git stash show \$(echo {}| cut -d: -f1) --color=always --ext-diff $forgit_fancy"
-    else
-      local preview_cmd="$FORGIT_STASH_PREVIEW"
-    fi
+    local preview_cmd="git stash show \$(echo {}| cut -d: -f1) --color=always --ext-diff $forgit_fancy"
     git stash list |
         forgit::fzf +s +m -0 --tiebreak=index \
         --bind="enter:execute($preview_cmd |LESS='-R' less)" \
-        --preview="$preview_cmd"
+        --preview="$preview_cmd" \
+        "$FORGIT_STASH_FZF_OPTS"
 }
 
 # git clean selector
@@ -113,10 +98,10 @@ forgit::ignore() {
     local IFS cmd args cat
     # https://github.com/sharkdp/bat.git
     hash bat &>/dev/null && cat='bat -l gitignore --color=always' || cat="cat"
-    cmd="$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
+    local preview_cmd="$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     # shellcheck disable=SC2206,2207
     IFS=$'\n' args=($@) && [[ $# -eq 0 ]] && args=($(forgit::ignore::list | nl -nrn -w4 -s'  ' |
-        forgit::fzf -m --preview="$preview_cmd" --preview-window="right:70%" | awk '{print $2}'))
+        forgit::fzf -m --preview-window="right:70%" --preview="$preview_cmd" "$FORGIT_IGNORE_FZF_OPTS" | awk '{print $2}'))
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     if hash bat &>/dev/null; then


### PR DESCRIPTION
May fix #21 as well.

I noticed this was especially needed in `forgit::add` because it's default preview command shows nothing for completely untracked files.