### PR TITLE
Add `grh` command for `git reset HEAD` (unstage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Interactive `git add` selector
 
 ![screenshot](https://raw.githubusercontent.com/wfxr/i/master/forgit-ga.png)
 
+### grh
+
+Interactive `git reset HEAD <file>` selector
+
 ### glo
 
 Interactive `git log` viewer
@@ -96,6 +100,7 @@ You can change the default aliases by defining these variables below.
 forgit_log=glo
 forgit_diff=gd
 forgit_add=ga
+forgit_reset_head=grh
 forgit_ignore=gi
 forgit_restore=gcf
 forgit_clean=gclean
@@ -117,15 +122,16 @@ FORGIT_FZF_DEFAULT_OPTS="
 
 Customizing fzf options for each command individually is also supported:
 
-| Command  | Option                     |
-| :------: | -------------------------- |
-| `ga`     | `FORGIT_ADD_FZF_OPTS`      |
-| `glo`    | `FORGIT_LOG_FZF_OPTS`      |
-| `gi`     | `FORGIT_IGNORE_FZF_OPTS`   |
-| `gd`     | `FORGIT_DIFF_FZF_OPTS`     |
-| `gcf`    | `FORGIT_CHECKOUT_FZF_OPTS` |
-| `gss`    | `FORGIT_STASH_FZF_OPTS`    |
-| `gclean` | `FORGIT_CLEAN_FZF_OPTS`    |
+| Command  | Option                       |
+|----------|------------------------------|
+| `ga`     | `FORGIT_ADD_FZF_OPTS`        |
+| `grh`    | `FORGIT_RESET_HEAD_FZF_OPTS` |
+| `glo`    | `FORGIT_LOG_FZF_OPTS`        |
+| `gi`     | `FORGIT_IGNORE_FZF_OPTS`     |
+| `gd`     | `FORGIT_DIFF_FZF_OPTS`       |
+| `gcf`    | `FORGIT_CHECKOUT_FZF_OPTS`   |
+| `gss`    | `FORGIT_STASH_FZF_OPTS`      |
+| `gclean` | `FORGIT_CLEAN_FZF_OPTS`      |
 
 The full loading order of fzf options is:
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -65,6 +65,21 @@ forgit::add() {
     echo 'Nothing to add.'
 }
 
+# git reset HEAD (unstage) selector
+forgit::reset::head() {
+    forgit::inside_work_tree || return 1
+    local cmd files opts
+    cmd="git diff --cached --color=always -- {} $forgit_emojify $forgit_fancy"
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        -m -0 --preview=\"$cmd\"
+        $FORGIT_RESET_HEAD_FZF_OPTS
+    "
+    files="$(git diff --cached --name-only | FZF_DEFAULT_OPTS="$opts" fzf)"
+    [[ -n "$files" ]] && echo "$files" |xargs -I{} git reset HEAD {} && git status --short && return
+    echo 'Nothing to unstage.'
+}
+
 # git checkout-restore selector
 forgit::restore() {
     forgit::inside_work_tree || return 1
@@ -180,6 +195,7 @@ $FORGIT_FZF_DEFAULT_OPTS
 # shellcheck disable=SC2139
 if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_add:-ga}"='forgit::add'
+    alias "${forgit_reset_head:-grh}"='forgit::reset::head'
     alias "${forgit_log:-glo}"='forgit::log'
     alias "${forgit_diff:-gd}"='forgit::diff'
     alias "${forgit_ignore:-gi}"='forgit::ignore'


### PR DESCRIPTION
I added `grh` (git reset HEAD) command to unstage the staged files. This is the opposite of `git add`.

Could you please review and add screenshot to README?

Hope you find this PR useful 🙂 