### PR TITLE
docs: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ zplug 'wfxr/forgit'
 zgen load 'wfxr/forgit'
 ```
 
-### [Antigen](https//github.com/zsh-users/antigen)
+### [Antigen](https://github.com/zsh-users/antigen)
 ``` zsh
 antigen bundle 'wfxr/forgit'
 ```


### PR DESCRIPTION
There was a missing colon in the antigen link, giving a 404 on github.com