### PR TITLE
Added -q flag for git reset HEAD

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -81,7 +81,7 @@ forgit::reset::head() {
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
     files="$(git diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf)"
-    [[ -n "$files" ]] && echo "$files" |xargs -I{} git reset HEAD {} && git status --short && return
+    [[ -n "$files" ]] && echo "$files" |xargs -I{} git reset -q HEAD {} && git status --short && return
     echo 'Nothing to unstage.'
 }
 


### PR DESCRIPTION
I wasn't sure whether this was intended or not, but I noticed that reset files are printed out twice: once by `git reset HEAD` and once by `git status` afterwards. I know that they are not printing exactly the same information, but to me, the first output is not really necessary. If you agree, feel free to merge.