### PR TITLE
add icdiff support and fix FORGIT_FZF_DEFAULT_OPTS being populated multiple times

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -66,7 +66,6 @@ forgit::icdiff() {
         $FORGIT_DIFF_FZF_OPTS
     "
 
-        # +m -0 --preview=\"$cmd\" --preview-window=down:90% --bind=\"enter:execute($cmd |LESS='-R' less)\"
     eval "git diff --name-only --relative $commit -- ${files[*]}"|
         FZF_DEFAULT_OPTS="$opts" fzf
 }

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -47,6 +47,31 @@ forgit::diff() {
         FZF_DEFAULT_OPTS="$opts" fzf
 }
 
+
+forgit::icdiff() {
+    forgit::inside_work_tree || return 1
+    local cmd files opts commit
+    [[ $# -ne 0 ]] && {
+        if git rev-parse "$1" -- &>/dev/null ; then
+            commit="$1" && files=("${@:2}")
+        else
+            files=("$@")
+        fi
+    }
+
+    cmd="git icdiff --color=always $commit -- {}"
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        +m -0 --preview=\"$cmd\" --preview-window=hidden --bind=\"enter:execute($cmd |LESS='-R' less)\"
+        $FORGIT_DIFF_FZF_OPTS
+    "
+
+        # +m -0 --preview=\"$cmd\" --preview-window=down:90% --bind=\"enter:execute($cmd |LESS='-R' less)\"
+    eval "git diff --name-only --relative $commit -- ${files[*]}"|
+        FZF_DEFAULT_OPTS="$opts" fzf
+}
+
+
 # git add selector
 forgit::add() {
     forgit::inside_work_tree || return 1
@@ -182,18 +207,17 @@ forgit::ignore::clean() {
     [[ -d "$FORGIT_GI_REPO_LOCAL" ]] && rm -rf "$FORGIT_GI_REPO_LOCAL"
 }
 
+
 FORGIT_FZF_DEFAULT_OPTS="
 $FZF_DEFAULT_OPTS
 --ansi
---height='80%'
---bind='alt-k:preview-up,alt-p:preview-up'
---bind='alt-j:preview-down,alt-n:preview-down'
+--bind='ctrl-p:preview-up,ctrl-n:preview-down'
 --bind='ctrl-r:toggle-all'
 --bind='ctrl-s:toggle-sort'
 --bind='?:toggle-preview'
---bind='alt-w:toggle-preview-wrap'
+--bind='ctrl-w:toggle-preview-wrap'
+--height='80%'
 --preview-window='right:60%'
-$FORGIT_FZF_DEFAULT_OPTS
 "
 
 # register aliases


### PR DESCRIPTION
Creating this for: https://github.com/wfxr/forgit/issues/37

Two things:

1. Not sure if it's a good thing to duplicated the code but think it's simpler to manage the switches. The icdiff view isn't rendered well in the not maximised preview window, hence hidden

2. Fir the bug that the FORGIT_FZF_DEFAULT_OPTS are populated a few times when my dotfile is loaded multiple times, maybe you intend to do it so.