### PR TITLE
Fixed issue with mutliple inputs to git commands using ctrl+r

### DIFF
--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -91,7 +91,7 @@ function forgit::add
         sed 's/.* -> //') # for rename case
 
     if test -n "$files"
-        echo "$files" |xargs -I{} git add {} && git status --short && return
+        echo $files | tr ' ' '\n' |xargs -I{} git add {} && git status --short && return
     end
     echo 'Nothing to add.'
 end
@@ -107,8 +107,7 @@ function forgit::reset::head
     "
     set files (git diff --cached --name-only --relative | env FZF_DEFAULT_OPTS="$opts" fzf)
     if test -n "$files"
-        echo herer
-        echo "$files" |xargs -I{} git reset -q HEAD {} && git status --short && return
+        echo $files | tr ' ' '\n' |xargs -I{} git reset -q HEAD {} && git status --short && return
     end
     echo 'Nothing to unstage.'
 end
@@ -126,7 +125,7 @@ function forgit::restore
     set git_rev_parse (git rev-parse --show-toplevel)
     set files (git ls-files --modified "$git_rev_parse" | env FZF_DEFAULT_OPTS="$opts" fzf)
     if test -n "$files"
-        echo "$files" |xargs -I{} git checkout {} && git status --short && return
+        echo $files | tr ' ' '\n' |xargs -I{} git checkout {} && git status --short && return
     end
     echo 'Nothing to restore.'
 end
@@ -156,7 +155,7 @@ function forgit::clean
     set files (git clean -xdfn $argv| awk '{print $3}'| env FZF_DEFAULT_OPTS="$opts" fzf |sed 's#/$##')
 
     if test -n "$files"
-        echo "$files" |xargs -I% git clean -xdf % && return
+        echo $files | tr ' ' '\n'|xargs -I{} git clean -xdf {} && return
     end
     echo 'Nothing to clean.'
 end


### PR DESCRIPTION
# Description

I noticed that the fish commands were not working on multi-select (using ctrl+r). 

Steps to repro:

1. Source fish version
2. modify multiple files
3. `ga`
4. ctrl+r
5. enter

Expected:
All files modified are add

Observed:
Crash :( 

This seems to have to do with the way fish arrays are stored. This seems to have fixed it!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Shells this fix should effect: 
- [ ] bash
- [ ] zsh 
- [x] fish 

## Shells this fix has been tested in: 
- [ ] bash
- [ ] zsh 
- [x] fish 

**Test Configuration**:
* OS: Mac OSX Mojave

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

@cjappl @wfxr
