### PR TITLE
:bug: fix typo in warning message

### DIFF
--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -14,7 +14,7 @@ function forgit::inside_work_tree
 end
 
 if not type -q fzf > /dev/null 2>&1
-     forgit::warn "FZF not found and is requried for forgit"
+     forgit::warn "FZF not found and is required for forgit"
      exit 1
 end
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -3,7 +3,7 @@ forgit::warn() { printf "%b[Warn]%b %s\n" '\e[0;33m' '\e[0m' "$@" >&2; }
 forgit::info() { printf "%b[Info]%b %s\n" '\e[0;32m' '\e[0m' "$@" >&2; }
 forgit::inside_work_tree() { git rev-parse --is-inside-work-tree >/dev/null; }
 
-hash fzf &>/dev/null || { forgit::warn "FZF not found and is requried for forgit"; return 1; }
+hash fzf &>/dev/null || { forgit::warn "FZF not found and is required for forgit"; return 1; }
 
 # https://github.com/wfxr/emoji-cli
 hash emojify &>/dev/null && forgit_emojify='|emojify'


### PR DESCRIPTION
# Description

I had issues installing forgit and ran into the warning message that has a typo. "reqiured" instead of "required". I then fixed it for you in the zsh and fish files. (spelled correctly in the sh file)

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

## Shells this fix should effect: 
- [ x] zsh 
- [ x] fish 

## Shells this fix has been tested in: 
- [ x] zsh 

**Test Configuration**:
* OS: 
```
Operating System: elementary OS 5.0 Juno
          Kernel: Linux 4.15.0-70-generic
    Architecture: x86-64
```

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code

@cjappl @wfxr
