### PR TITLE
Diff staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You can change the default aliases by defining these variables below.
 # Define them before sourcing the plugin if you don't use any plugin manager.
 forgit_log=glo
 forgit_diff=gd
+forgit_diff_staged=gds
 forgit_add=ga
 forgit_reset_head=grh
 forgit_ignore=gi
@@ -137,6 +138,7 @@ Customizing fzf options for each command individually is also supported:
 | `glo`    | `FORGIT_LOG_FZF_OPTS`        |
 | `gi`     | `FORGIT_IGNORE_FZF_OPTS`     |
 | `gd`     | `FORGIT_DIFF_FZF_OPTS`       |
+| `gds`    | `FORGIT_DIFF_STAGED_FZF_OPTS`|
 | `grh`    | `FORGIT_RESET_HEAD_FZF_OPTS` |
 | `gcf`    | `FORGIT_CHECKOUT_FZF_OPTS`   |
 | `gss`    | `FORGIT_STASH_FZF_OPTS`      |

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -73,6 +73,28 @@ function forgit::diff
     env FZF_DEFAULT_OPTS="$opts" fzf
 end
 
+## git diff viewer
+function forgit::diff::staged
+    forgit::inside_work_tree || return 1
+    if not count $argv > /dev/null
+        set files "$argv"
+    end
+
+    set repo "(git rev-parse --show-toplevel)"
+    set target "\(echo {} | sed 's/.*]  //')"
+    set cmd "git diff --staged --color=always -- $repo/$target | $forgit_pager"
+    set opts "
+        $FORGIT_FZF_DEFAULT_OPTS
+        +m -0 --preview=\"$cmd\" --bind=\"enter:execute($cmd |env LESS='-R' less)\"
+        $FORGIT_DIFF_STAGED_FZF_OPTS
+    "
+    set cmd "echo" && type -q realpath > /dev/null 2>&1 && set cmd "realpath --relative-to=."
+    set git_rev_parse (git rev-parse --show-toplevel)
+    eval "git diff --staged --name-only -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" |
+
+    env FZF_DEFAULT_OPTS="$opts" fzf
+end
+
 # git add selector
 function forgit::add
     forgit::inside_work_tree || return 1
@@ -304,6 +326,12 @@ if test -z "$FORGIT_NO_ALIASES"
         alias $forgit_diff 'forgit::diff'
     else
         alias gd 'forgit::diff'
+    end
+
+    if test -n "$forgit_diff_staged"
+        alias $forgit_diff_staged 'forgit::diff::staged'
+    else
+        alias gds 'forgit::diff::staged'
     end
 
     if test -n "$forgit_ignore"

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -27,14 +27,16 @@ forgit::log() {
 # git diff viewer
 forgit::diff() {
     forgit::inside_work_tree || return 1
-    local cmd files opts commit repo
+    local cmd opts args commit repo
+    args=()
     [[ $# -ne 0 ]] && {
         if git rev-parse "$1" -- &>/dev/null ; then
-            commit="$1" && files=("${@:2}")
+            commit="$1"
+            args+=("$1" "--" "${@:2}")
         else
-            files=("$@")
+            args+=("--" "$@")
         fi
-    } || files=(".")
+    }
 
     repo="$(git rev-parse --show-toplevel)"
     target="\$(echo {} | sed 's/.*]  //')"
@@ -44,15 +46,15 @@ forgit::diff() {
         +m -0 --preview=\"$cmd\" --bind=\"enter:execute($cmd |LESS='-R' less)\"
         $FORGIT_DIFF_FZF_OPTS
     "
-    git diff --name-status "$commit" -- "${files[@]}" | sed -E 's/^(.)[[:space:]]+(.*)$/[\1]  \2/' |
+    git diff --name-status "${args[@]}" | sed -E 's/^(.)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf
 }
 
 # git diff viewer (staged)
 forgit::diff::staged() {
     forgit::inside_work_tree || return 1
-    local cmd files opts repo
-    [[ $# -ne 0 ]] && files=("$@") || files=(".")
+    local cmd args opts repo
+    [[ $# -ne 0 ]] && args=("--" "$@")
 
     repo="$(git rev-parse --show-toplevel)"
     target="\$(echo {} | sed 's/.*]  //')"
@@ -62,7 +64,7 @@ forgit::diff::staged() {
         +m -0 --preview=\"$cmd\" --bind=\"enter:execute($cmd |LESS='-R' less)\"
         $FORGIT_DIFF_STAGED_FZF_OPTS
     "
-    git diff --staged --name-status -- "${files[@]}" | sed -E 's/^(.)[[:space:]]+(.*)$/[\1]  \2/' |
+    git diff --staged --name-status "${args[@]}" | sed -E 's/^(.)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf
 }
 


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description
This adds a new alias `gds` that acts the same as `gd` but it shows the staged changes. The alias `gd` has an argument `$1` which can be `commit`, this has been removed since this is invalid when reviewing staged commits.

In addition, the `eval` command has been removed for the function `forgit::diff`, and isn't used in `forgit::diff::staged`. This should make forgit that bit safer.

Note that I do not have fish or do I plan on installing it, so while, I did my best to provide the same functionality for fish, this has unfortunately not been tested. I'm happy to back out this change if necessary.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
