### PR TITLE
fzf preview bug fixed

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -93,10 +93,10 @@ forgit::reset::head() {
     cmd="git diff --cached --color=always -- {} | $forgit_pager "
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        -m -0 --preview=\"$cmd\"
+        -m -0
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    files="$(git diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf)"
+    files="$(git diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD % && git status --short && return
     echo 'Nothing to unstage.'
 }
@@ -108,10 +108,10 @@ forgit::restore() {
     cmd="git diff --color=always -- {} | $forgit_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        -m -0 --preview=\"$cmd\"
+        -m -0
         $FORGIT_CHECKOUT_FZF_OPTS
     "
-    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf)"
+    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git checkout % && git status --short && return
     echo 'Nothing to restore.'
 }
@@ -123,10 +123,10 @@ forgit::stash::show() {
     cmd="git stash show \$(echo {}| cut -d: -f1) --color=always --ext-diff | $forgit_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m -0 --tiebreak=index --preview=\"$cmd\" --bind=\"enter:execute($cmd | LESS='-R' less)\"
+        +s +m -0 --tiebreak=index --bind=\"enter:execute($cmd | LESS='-R' less)\"
         $FORGIT_STASH_FZF_OPTS
     "
-    git stash list | FZF_DEFAULT_OPTS="$opts" fzf
+    git stash list | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 
 # git clean selector
@@ -157,12 +157,12 @@ forgit::ignore() {
     cmd="$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        -m --preview=\"$cmd\" --preview-window='right:70%'
+        -m --preview-window='right:70%'
         $FORGIT_IGNORE_FZF_OPTS
     "
     # shellcheck disable=SC2206,2207
     IFS=$'\n' args=($@) && [[ $# -eq 0 ]] && args=($(forgit::ignore::list | nl -nrn -w4 -s'  ' |
-        FZF_DEFAULT_OPTS="$opts" fzf  |awk '{print $2}'))
+        FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd" |awk '{print $2}'))
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     if hash bat &>/dev/null; then

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -15,13 +15,13 @@ forgit::log() {
     cmd="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % $* | $forgit_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m --tiebreak=index --preview=\"$cmd\"
+        +s +m --tiebreak=index
         --bind=\"enter:execute($cmd | LESS='-R' less)\"
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '\n' |${FORGIT_COPY_CMD:-pbcopy})\"
         $FORGIT_LOG_FZF_OPTS
     "
     eval "git log --graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $* $forgit_emojify" |
-        FZF_DEFAULT_OPTS="$opts" fzf
+        FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 
 # git diff viewer
@@ -41,11 +41,11 @@ forgit::diff() {
     cmd="git diff --color=always $commit -- $repo/$target | $forgit_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +m -0 --preview=\"$cmd\" --bind=\"enter:execute($cmd |LESS='-R' less)\"
+        +m -0 --bind=\"enter:execute($cmd |LESS='-R' less)\"
         $FORGIT_DIFF_FZF_OPTS
     "
     eval "git diff --name-status $commit -- ${files[*]} | sed -E 's/^(.)[[:space:]]+(.*)$/[\1]  \2/'" |
-        FZF_DEFAULT_OPTS="$opts" fzf
+        FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 
 # git add selector
@@ -75,13 +75,12 @@ forgit::add() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
-        --preview=\"$preview\"
         $FORGIT_ADD_FZF_OPTS
     "
     files=$(git -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
-        FZF_DEFAULT_OPTS="$opts" fzf |
+        FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
         sh -c "$extract")
     [[ -n "$files" ]] && echo "$files"| tr '\n' '\0' |xargs -0 -I% git add % && git status -su && return
     echo 'Nothing to add.'


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:

## Comment

This is [my issue](https://github.com/wfxr/forgit/issues/76) solution.
I was constantly getting error from bat: `no such file: [M] file-name`, but I was using diff-so-fancy as pager.
The thing was in fzf environment variable (fzf latest version 0.20.0), and it is even mentioned in [fzf's README](https://github.com/junegunn/fzf#preview-window): "Since fzf is a general-purpose text filter rather than a file finder, it is not a good idea to add `--preview` option to your `$FZF_DEFAULT_OPTS`"