### PR TITLE
Allow files as arguments to `forgit:reset:head`

### DIFF
--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -127,6 +127,9 @@ end
 ## git reset HEAD (unstage) selector
 function forgit::reset::head
     forgit::inside_work_tree || return 1
+    # Reset HEAD of specific files, if passed as arguments
+    count $argv >/dev/null && git reset -q HEAD "$argv" && git status --short && return
+
     set cmd "git diff --cached --color=always -- {} | $forgit_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -91,6 +91,9 @@ forgit::add() {
 # git reset HEAD (unstage) selector
 forgit::reset::head() {
     forgit::inside_work_tree || return 1
+    # Reset HEAD of specific files, if passed as arguments
+    [[ $# -ne 0 ]] && git reset -q HEAD "$@" && git status --short && return
+
     local cmd files opts
     cmd="git diff --cached --color=always -- {} | $forgit_pager "
     opts="


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description
Adds a case where `grh` (`forgit:reset:head`) can accept files as arguments that will be passed directly to `git reset -q HEAD ...`, bypassing `fzf`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
