### PR TITLE
The bug in fish <3.1 is resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ source <(curl -s https://raw.githubusercontent.com/wfxr/forgit/master/forgit.plu
 source (curl -s https://raw.githubusercontent.com/wfxr/forgit/master/forgit.plugin.fish | psub)
 ```
 
-*NOTE: `fish` 3.1 is not currently supported. (see [issue #87](https://github.com/wfxr/forgit/issues/87))*
-
 ### 📝 Features
 
 - **Interactive `git add` selector** (`ga`)


### PR DESCRIPTION
The bug in 3.1 was solved by https://github.com/fish-shell/fish-shell/issues/6955

Resolves #87

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [ x] I have performed a self-review of my code
- [ x] I have commented my code in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ x] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh 
    - [x] fish 
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
