### PR TITLE
Configurable pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ forgit_clean=gclean
 forgit_stash_show=gss
 ```
 
+Forgit will use the default configured pager from git (`core.pager`,
+`pager.show`, `pager.diff`) but can be altered with the following environment
+variables:
+
+| Use case            | Option              | Fallbacks to                                 |
+| ------------        | ------------------- | -------------------------------------------- |
+| fallback pager      | `FORGIT_PAGER`      | `git config core.pager` _or_ `cat`           |
+| pager on `git show` | `FORGIT_PAGER_SHOW` | `git config pager.show` _or_ `$FORGIT_PAGER` |
+| pager on `git diff` | `FORGIT_PAGER_DIFF` | `git config pager.diff` _or_ `$FORGIT_PAGER` |
+
 You can add default fzf options for `forgit`, including keybinds, layout, etc.
 (No need to repeat the options already defined in `FZF_DEFAULT_OPTS`)
 

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -22,7 +22,7 @@ test -z "$forgit_show_pager"; and set forgit_show_pager (git config pager.show |
 test -z "$forgit_diff_pager"; and set forgit_diff_pager (git config pager.diff || echo "$forgit_pager")
 
 # used whenever piping to disable any pager like 'less'
-set gitP git --no-pager
+set forgit_git_no_pager git --no-pager
 
 # https://github.com/wfxr/emoji-cli
 type -q emojify >/dev/null 2>&1 && set forgit_emojify '|emojify'
@@ -32,7 +32,7 @@ function forgit::log
     forgit::inside_work_tree || return 1
 
     set files (echo $argv | sed -nE 's/.* -- (.*)/\1/p')
-    set cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% $gitP show --color=always % -- $files | $forgit_show_pager"
+    set cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% $forgit_git_no_pager show --color=always % -- $files | $forgit_show_pager"
 
     if test -n "$FORGIT_COPY_CMD"
         set copy_cmd $FORGIT_COPY_CMD
@@ -54,7 +54,7 @@ function forgit::log
         set graph ""
     end
 
-    eval "$gitP log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $argv $forgit_emojify" |
+    eval "$forgit_git_no_pager log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $argv $forgit_emojify" |
         env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 end
 
@@ -77,9 +77,9 @@ function forgit::diff
         $FORGIT_DIFF_FZF_OPTS
     "
 
-    set cmd "echo {} |sed 's/.*]  //' | xargs -I% $gitP diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
+    set cmd "echo {} |sed 's/.*]  //' | xargs -I% $forgit_git_no_pager diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
 
-    eval "$gitP diff --name-only $commit -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
+    eval "$forgit_git_no_pager diff --name-only $commit -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 end
 
 # git add selector
@@ -101,10 +101,10 @@ function forgit::add
     set preview "
         set file (echo {} | $extract_file)
         # exit
-        if test ($gitP status -s -- \$file | grep '^??') # diff with /dev/null for untracked files
-            $gitP diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
+        if test ($forgit_git_no_pager status -s -- \$file | grep '^??') # diff with /dev/null for untracked files
+            $forgit_git_no_pager diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
         else
-            $gitP diff --color=always -- \$file | $forgit_diff_pager
+            $forgit_git_no_pager diff --color=always -- \$file | $forgit_diff_pager
         end
         "
     set opts "
@@ -112,7 +112,7 @@ function forgit::add
         -0 -m --nth 2..,..
         $FORGIT_ADD_FZF_OPTS
     "
-    set files ($gitP -c color.status=always -c status.relativePaths=true status -su |
+    set files ($forgit_git_no_pager -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)\$/[\1]  \2/' |   # deal with white spaces internal to fname
         env FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
@@ -131,13 +131,13 @@ end
 ## git reset HEAD (unstage) selector
 function forgit::reset::head
     forgit::inside_work_tree || return 1
-    set cmd "$gitP diff --cached --color=always -- {} | $forgit_diff_pager"
+    set cmd "$forgit_git_no_pager diff --cached --color=always -- {} | $forgit_diff_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    set files ($gitP diff --cached --name-only --relative | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
+    set files ($forgit_git_no_pager diff --cached --name-only --relative | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
     if test -n "$files"
         for file in $files
             echo $file | tr '\n' '\0' |xargs -I{} -0 git reset -q HEAD {}
@@ -152,14 +152,14 @@ end
 function forgit::checkout_file
     forgit::inside_work_tree || return 1
 
-    set cmd "$gitP diff --color=always -- {} | $forgit_diff_pager"
+    set cmd "$forgit_git_no_pager diff --color=always -- {} | $forgit_diff_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_CHECKOUT_FZF_OPTS
     "
     set git_rev_parse (git rev-parse --show-toplevel)
-    set files ($gitP ls-files --modified "$git_rev_parse" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
+    set files ($forgit_git_no_pager ls-files --modified "$git_rev_parse" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
     if test -n "$files"
         for file in $files
             echo $file | tr '\n' '\0' | xargs -I{} -0 git checkout -q {} 

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -21,9 +21,6 @@ test -z "$forgit_pager"; and set forgit_pager (git config core.pager || echo 'ca
 test -z "$forgit_show_pager"; and set forgit_show_pager (git config pager.show || echo "$forgit_pager")
 test -z "$forgit_diff_pager"; and set forgit_diff_pager (git config pager.diff || echo "$forgit_pager")
 
-# used whenever piping to disable any pager like 'less'
-set forgit_git_no_pager git --no-pager
-
 # https://github.com/wfxr/emoji-cli
 type -q emojify >/dev/null 2>&1 && set forgit_emojify '|emojify'
 
@@ -32,7 +29,7 @@ function forgit::log
     forgit::inside_work_tree || return 1
 
     set files (echo $argv | sed -nE 's/.* -- (.*)/\1/p')
-    set cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% $forgit_git_no_pager show --color=always % -- $files | $forgit_show_pager"
+    set cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git --no-pager show --color=always % -- $files | $forgit_show_pager"
 
     if test -n "$FORGIT_COPY_CMD"
         set copy_cmd $FORGIT_COPY_CMD
@@ -54,7 +51,7 @@ function forgit::log
         set graph ""
     end
 
-    eval "$forgit_git_no_pager log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $argv $forgit_emojify" |
+    eval "git --no-pager log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $argv $forgit_emojify" |
         env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 end
 
@@ -77,9 +74,9 @@ function forgit::diff
         $FORGIT_DIFF_FZF_OPTS
     "
 
-    set cmd "echo {} |sed 's/.*]  //' | xargs -I% $forgit_git_no_pager diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
+    set cmd "echo {} |sed 's/.*]  //' | xargs -I% git --no-pager diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
 
-    eval "$forgit_git_no_pager diff --name-only $commit -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
+    eval "git --no-pager diff --name-only $commit -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 end
 
 # git add selector
@@ -101,10 +98,10 @@ function forgit::add
     set preview "
         set file (echo {} | $extract_file)
         # exit
-        if test ($forgit_git_no_pager status -s -- \$file | grep '^??') # diff with /dev/null for untracked files
-            $forgit_git_no_pager diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
+        if test (git --no-pager status -s -- \$file | grep '^??') # diff with /dev/null for untracked files
+            git --no-pager diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
         else
-            $forgit_git_no_pager diff --color=always -- \$file | $forgit_diff_pager
+            git --no-pager diff --color=always -- \$file | $forgit_diff_pager
         end
         "
     set opts "
@@ -112,7 +109,7 @@ function forgit::add
         -0 -m --nth 2..,..
         $FORGIT_ADD_FZF_OPTS
     "
-    set files ($forgit_git_no_pager -c color.status=always -c status.relativePaths=true status -su |
+    set files (git --no-pager -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)\$/[\1]  \2/' |   # deal with white spaces internal to fname
         env FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
@@ -131,13 +128,13 @@ end
 ## git reset HEAD (unstage) selector
 function forgit::reset::head
     forgit::inside_work_tree || return 1
-    set cmd "$forgit_git_no_pager diff --cached --color=always -- {} | $forgit_diff_pager"
+    set cmd "git --no-pager diff --cached --color=always -- {} | $forgit_diff_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    set files ($forgit_git_no_pager diff --cached --name-only --relative | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
+    set files (git --no-pager diff --cached --name-only --relative | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
     if test -n "$files"
         for file in $files
             echo $file | tr '\n' '\0' |xargs -I{} -0 git reset -q HEAD {}
@@ -152,14 +149,14 @@ end
 function forgit::checkout_file
     forgit::inside_work_tree || return 1
 
-    set cmd "$forgit_git_no_pager diff --color=always -- {} | $forgit_diff_pager"
+    set cmd "git --no-pager diff --color=always -- {} | $forgit_diff_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_CHECKOUT_FZF_OPTS
     "
     set git_rev_parse (git rev-parse --show-toplevel)
-    set files ($forgit_git_no_pager ls-files --modified "$git_rev_parse" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
+    set files (git --no-pager ls-files --modified "$git_rev_parse" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
     if test -n "$files"
         for file in $files
             echo $file | tr '\n' '\0' | xargs -I{} -0 git checkout -q {} 

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -29,7 +29,7 @@ function forgit::log
     forgit::inside_work_tree || return 1
 
     set files (echo $argv | sed -nE 's/.* -- (.*)/\1/p')
-    set cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git --no-pager show --color=always % -- $files | $forgit_show_pager"
+    set cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
 
     if test -n "$FORGIT_COPY_CMD"
         set copy_cmd $FORGIT_COPY_CMD
@@ -51,7 +51,7 @@ function forgit::log
         set graph ""
     end
 
-    eval "git --no-pager log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $argv $forgit_emojify" |
+    eval "git log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $argv $forgit_emojify" |
         env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 end
 
@@ -74,9 +74,9 @@ function forgit::diff
         $FORGIT_DIFF_FZF_OPTS
     "
 
-    set cmd "echo {} |sed 's/.*]  //' | xargs -I% git --no-pager diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
+    set cmd "echo {} |sed 's/.*]  //' | xargs -I% git diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
 
-    eval "git --no-pager diff --name-only $commit -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
+    eval "git diff --name-only $commit -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 end
 
 # git add selector
@@ -98,10 +98,10 @@ function forgit::add
     set preview "
         set file (echo {} | $extract_file)
         # exit
-        if test (git --no-pager status -s -- \$file | grep '^??') # diff with /dev/null for untracked files
-            git --no-pager diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
+        if test (git status -s -- \$file | grep '^??') # diff with /dev/null for untracked files
+            git diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
         else
-            git --no-pager diff --color=always -- \$file | $forgit_diff_pager
+            git diff --color=always -- \$file | $forgit_diff_pager
         end
         "
     set opts "
@@ -109,7 +109,7 @@ function forgit::add
         -0 -m --nth 2..,..
         $FORGIT_ADD_FZF_OPTS
     "
-    set files (git --no-pager -c color.status=always -c status.relativePaths=true status -su |
+    set files (git -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)\$/[\1]  \2/' |   # deal with white spaces internal to fname
         env FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
@@ -128,13 +128,13 @@ end
 ## git reset HEAD (unstage) selector
 function forgit::reset::head
     forgit::inside_work_tree || return 1
-    set cmd "git --no-pager diff --cached --color=always -- {} | $forgit_diff_pager"
+    set cmd "git diff --cached --color=always -- {} | $forgit_diff_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    set files (git --no-pager diff --cached --name-only --relative | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
+    set files (git diff --cached --name-only --relative | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
     if test -n "$files"
         for file in $files
             echo $file | tr '\n' '\0' |xargs -I{} -0 git reset -q HEAD {}
@@ -149,14 +149,14 @@ end
 function forgit::checkout_file
     forgit::inside_work_tree || return 1
 
-    set cmd "git --no-pager diff --color=always -- {} | $forgit_diff_pager"
+    set cmd "git diff --color=always -- {} | $forgit_diff_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_CHECKOUT_FZF_OPTS
     "
     set git_rev_parse (git rev-parse --show-toplevel)
-    set files (git --no-pager ls-files --modified "$git_rev_parse" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
+    set files (git ls-files --modified "$git_rev_parse" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")
     if test -n "$files"
         for file in $files
             echo $file | tr '\n' '\0' | xargs -I{} -0 git checkout -q {} 

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -13,10 +13,13 @@ function forgit::inside_work_tree
     git rev-parse --is-inside-work-tree >/dev/null;
 end
 
-set forgit_pager (git config core.pager || echo 'cat')
-set forgit_show_pager (git config pager.show || echo "$forgit_pager")
-set forgit_diff_pager (git config pager.diff || echo "$forgit_pager")
+set forgit_pager "$FORGIT_PAGER"
+set forgit_show_pager "$FORGIT_SHOW_PAGER"
+set forgit_diff_pager "$FORGIT_DIFF_PAGER"
 
+test -z "$forgit_pager"; and set forgit_pager (git config core.pager || echo 'cat')
+test -z "$forgit_show_pager"; and set forgit_show_pager (git config pager.show || echo "$forgit_pager")
+test -z "$forgit_diff_pager"; and set forgit_diff_pager (git config pager.diff || echo "$forgit_pager")
 
 # https://github.com/wfxr/emoji-cli
 type -q emojify >/dev/null 2>&1 && set forgit_emojify '|emojify'

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -59,7 +59,7 @@ forgit::diff() {
 forgit::add() {
     forgit::inside_work_tree || return 1
     # Add files if passed as arguments
-    [[ $# -ne 0 ]] && git add "$@" && $git status -su && return
+    [[ $# -ne 0 ]] && git add "$@" && git status -su && return
 
     local changed unmerged untracked files opts preview extract
     changed=$(git config --get-color color.status.changed red)
@@ -88,7 +88,7 @@ forgit::add() {
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
         sh -c "$extract")
-    [[ -n "$files" ]] && echo "$files"| tr '\n' '\0' |xargs -0 -I% git add % && $git status -su && return
+    [[ -n "$files" ]] && echo "$files"| tr '\n' '\0' |xargs -0 -I% git add % && git status -su && return
     echo 'Nothing to add.'
 }
 
@@ -103,7 +103,7 @@ forgit::reset::head() {
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
     files="$($forgit_git_no_pager diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
-    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD % && $git status --short && return
+    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD % && git status --short && return
     echo 'Nothing to unstage.'
 }
 
@@ -117,8 +117,8 @@ forgit::restore() {
         -m -0
         $FORGIT_CHECKOUT_FZF_OPTS
     "
-    files="$($forgit_git_no_pager ls-files --modified "$($git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
-    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git checkout % && $git status --short && return
+    files="$($forgit_git_no_pager ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
+    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git checkout % && git status --short && return
     echo 'Nothing to restore.'
 }
 
@@ -146,7 +146,7 @@ forgit::clean() {
     "
     # Note: Postfix '/' in directory path should be removed. Otherwise the directory itself will not be removed.
     files=$($forgit_git_no_pager clean -xdfn "$@"| sed 's/^Would remove //' | FZF_DEFAULT_OPTS="$opts" fzf |sed 's#/$##')
-    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git clean -xdf '%' && $git status --short && return
+    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git clean -xdf '%' && git status --short && return
     echo 'Nothing to clean.'
 }
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -16,7 +16,7 @@ forgit::log() {
     forgit::inside_work_tree || return 1
     local cmd opts graph files
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
-    cmd="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git --no-pager show --color=always % -- $files | $forgit_show_pager"
+    cmd="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
@@ -26,7 +26,7 @@ forgit::log() {
     "
     graph=--graph
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
-    eval "git --no-pager log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $* $forgit_emojify" |
+    eval "git log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr' $* $forgit_emojify" |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 
@@ -35,20 +35,20 @@ forgit::diff() {
     forgit::inside_work_tree || return 1
     local cmd files opts commit repo
     [[ $# -ne 0 ]] && {
-        if git --no-pager rev-parse "$1" -- &>/dev/null ; then
+        if git rev-parse "$1" -- &>/dev/null ; then
             commit="$1" && files=("${@:2}")
         else
             files=("$@")
         fi
     }
-    repo="$(git --no-pager rev-parse --show-toplevel)"
-    cmd="echo {} |sed 's/.*]  //' |xargs -I% git --no-pager diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
+    repo="$(git rev-parse --show-toplevel)"
+    cmd="echo {} |sed 's/.*]  //' |xargs -I% git diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($cmd |LESS='-R' less)\"
         $FORGIT_DIFF_FZF_OPTS
     "
-    eval "git --no-pager diff --name-status $commit -- ${files[*]} | sed -E 's/^(.)[[:space:]]+(.*)$/[\1]  \2/'" |
+    eval "git diff --name-status $commit -- ${files[*]} | sed -E 's/^(.)[[:space:]]+(.*)$/[\1]  \2/'" |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 
@@ -70,17 +70,17 @@ forgit::add() {
         sed -e 's/^\\\"//' -e 's/\\\"\$//'"
     preview="
         file=\$(echo {} | $extract)
-        if (git --no-pager status -s -- \$file | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
-            git --no-pager diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
+        if (git status -s -- \$file | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
+            git diff --color=always --no-index -- /dev/null \$file | $forgit_diff_pager | sed '2 s/added:/untracked:/'
         else
-            git --no-pager diff --color=always -- \$file | $forgit_diff_pager
+            git diff --color=always -- \$file | $forgit_diff_pager
         fi"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
         $FORGIT_ADD_FZF_OPTS
     "
-    files=$(git --no-pager -c color.status=always -c status.relativePaths=true status -su |
+    files=$(git -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
@@ -93,13 +93,13 @@ forgit::add() {
 forgit::reset::head() {
     forgit::inside_work_tree || return 1
     local cmd files opts
-    cmd="git --no-pager diff --cached --color=always -- {} | $forgit_diff_pager "
+    cmd="git diff --cached --color=always -- {} | $forgit_diff_pager "
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    files="$(git --no-pager diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
+    files="$(git diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD % && git status --short && return
     echo 'Nothing to unstage.'
 }
@@ -108,13 +108,13 @@ forgit::reset::head() {
 forgit::restore() {
     forgit::inside_work_tree || return 1
     local cmd files opts
-    cmd="git --no-pager diff --color=always -- {} | $forgit_diff_pager"
+    cmd="git diff --color=always -- {} | $forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         $FORGIT_CHECKOUT_FZF_OPTS
     "
-    files="$(git --no-pager ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
+    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git checkout % && git status --short && return
     echo 'Nothing to restore.'
 }
@@ -123,13 +123,13 @@ forgit::restore() {
 forgit::stash::show() {
     forgit::inside_work_tree || return 1
     local cmd opts
-    cmd="echo {} |cut -d: -f1 |xargs -I% git --no-pager stash show --color=always --ext-diff % |$forgit_diff_pager"
+    cmd="echo {} |cut -d: -f1 |xargs -I% git stash show --color=always --ext-diff % |$forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m -0 --tiebreak=index --bind=\"enter:execute($cmd | LESS='-R' less)\"
         $FORGIT_STASH_FZF_OPTS
     "
-    git --no-pager stash list | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
+    git stash list | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 
 # git clean selector
@@ -142,7 +142,7 @@ forgit::clean() {
         $FORGIT_CLEAN_FZF_OPTS
     "
     # Note: Postfix '/' in directory path should be removed. Otherwise the directory itself will not be removed.
-    files=$(git --no-pager clean -xdfn "$@"| sed 's/^Would remove //' | FZF_DEFAULT_OPTS="$opts" fzf |sed 's#/$##')
+    files=$(git clean -xdfn "$@"| sed 's/^Would remove //' | FZF_DEFAULT_OPTS="$opts" fzf |sed 's#/$##')
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git clean -xdf '%' && git status --short && return
     echo 'Nothing to clean.'
 }

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -7,9 +7,9 @@ forgit::inside_work_tree() { git rev-parse --is-inside-work-tree >/dev/null; }
 # https://github.com/wfxr/emoji-cli
 hash emojify &>/dev/null && forgit_emojify='|emojify'
 
-forgit_pager=$(git config core.pager || echo 'cat')
-forgit_show_pager=$(git config pager.show || echo "$forgit_pager")
-forgit_diff_pager=$(git config pager.diff || echo "$forgit_pager")
+forgit_pager=${FORGIT_PAGER:-$(git config core.pager || echo 'cat')}
+forgit_show_pager=${FORGIT_SHOW_PAGER:-$(git config pager.show || echo "$forgit_pager")}
+forgit_diff_pager=${FORGIT_DIFF_PAGER:-$(git config pager.diff || echo "$forgit_pager")}
 
 # git commit viewer
 forgit::log() {


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

I have a use case where I need to override the pager config, so I thought I'd write a PR on the case.

My use case is that I'm using WSL 2 where they still have super slow file access across the distros. To conquer that I'm using a small script in my WSL instead of git that goes something like this:

```bash
#! /bin/bash

LINUX_GIT='/usr/bin/git'
WINDOWS_GIT='git.exe'

WORKING_DIR="$(pwd)"

if [[ "${WORKING_DIR:0:3}" == '/c/' ]]; then
	$WINDOWS_GIT "$@"
else
	$LINUX_GIT "$@"
fi
```

Using the interopability to my advantage to use either git inside my WSL or inside my Windows host machine depending on which repo I'm working on. Making it blazing fast in comparison to only using the WSL git.

Problem then arises with the pager. Since it's pointing to my `git.exe` when targeting repos on my Windows host machine then it fetches the paging config from my host machine, which in my case depends on different programs and different syntax (ex WSL core.pager: `diff-so-fancy`, ex Windows core.pager: `diff-so-fancy.cmd`).

Instead of having to do some weird workarounds of a `core.pager` config that works on both windows and linux, I would find it being configurable to be much easier to use. With these changes, whenever I'm using the `forgit::log` function from my WSL I can override it to use a WSL based pager and ignore all my windows options.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
