### PR TITLE
FORGIT_BAT_OPTS to add options to bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ FORGIT_FZF_DEFAULT_OPTS="
 "
 ```
 
+You can set [bat](https://github.com/sharkdp/bat) options with `FORGIT_BAT_OPTION`.
+default option is `FORGIT_BAT_OPTION="--color=always"`
+
+``` bash
+# this is a example. see bat --help
+FORGIT_BAT_OPTION='-pp --color=always --theme="Monokai Extended Origin"'
+```
+
 Customizing fzf options for each command individually is also supported:
 
 | Command  | Option                       |

--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ FORGIT_FZF_DEFAULT_OPTS="
 "
 ```
 
-You can set [bat](https://github.com/sharkdp/bat) options with `FORGIT_BAT_OPTS`.
-default option is `FORGIT_BAT_OPTS="--color=always"`
+You can forgit gitignore pager with `FORGIT_IGNORE_PAGER`.
+default option is `FORGIT_IGNORE_PAGER="bat -l gitignore --color=always"`
 
 ``` bash
 # this is a example. see bat --help
-FORGIT_BAT_OPTS='-pp --color=always --theme="Monokai Extended Origin"'
+FORGIT_IGNORE_PAGER='bat -l gitignore -pp --color=always --theme="Monokai Extended Origin"'
 ```
 
 Customizing fzf options for each command individually is also supported:

--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ FORGIT_FZF_DEFAULT_OPTS="
 "
 ```
 
-You can set [bat](https://github.com/sharkdp/bat) options with `FORGIT_BAT_OPTION`.
-default option is `FORGIT_BAT_OPTION="--color=always"`
+You can set [bat](https://github.com/sharkdp/bat) options with `FORGIT_BAT_OPTS`.
+default option is `FORGIT_BAT_OPTS="--color=always"`
 
 ``` bash
 # this is a example. see bat --help
-FORGIT_BAT_OPTION='-pp --color=always --theme="Monokai Extended Origin"'
+FORGIT_BAT_OPTS='-pp --color=always --theme="Monokai Extended Origin"'
 ```
 
 Customizing fzf options for each command individually is also supported:

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -244,7 +244,7 @@ function forgit::ignore
     end
 
     # https://github.com/sharkdp/bat.git
-    type -q bat > /dev/null 2>&1 && set cat 'bat -l gitignore '"${FORGIT_BAT_OPTION}" || set cat "cat"
+    type -q bat > /dev/null 2>&1 && set cat 'bat -l gitignore '"$FORGIT_BAT_OPTION" || set cat "cat"
     set cmd "$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
@@ -264,7 +264,7 @@ function forgit::ignore
      end
 
     if type -q bat > /dev/null 2>&1
-        forgit::ignore::get $args | bat -l gitignore "${FORGIT_BAT_OPTION}" 
+        forgit::ignore::get $args | bat -l gitignore "$FORGIT_BAT_OPTION" 
     else
         forgit::ignore::get $args
     end

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -234,8 +234,8 @@ if test -z "$FORGIT_GI_TEMPLATES"
     set -x FORGIT_GI_TEMPLATES $FORGIT_GI_REPO_LOCAL/templates
 end
 
-if test -z "FORGIT_BAT_OPTION"
-    set -x FORGIT_BAT_OPTION --color=always
+if test -z "FORGIT_BAT_OPTS"
+    set -x FORGIT_BAT_OPTS --color=always
 end
 
 function forgit::ignore
@@ -244,7 +244,7 @@ function forgit::ignore
     end
 
     # https://github.com/sharkdp/bat.git
-    type -q bat > /dev/null 2>&1 && set cat 'bat -l gitignore '"$FORGIT_BAT_OPTION" || set cat "cat"
+    type -q bat > /dev/null 2>&1 && set cat 'bat -l gitignore '"$FORGIT_BAT_OPTS" || set cat "cat"
     set cmd "$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
@@ -264,7 +264,7 @@ function forgit::ignore
      end
 
     if type -q bat > /dev/null 2>&1
-        forgit::ignore::get $args | bat -l gitignore "$FORGIT_BAT_OPTION" 
+        forgit::ignore::get $args | bat -l gitignore "$FORGIT_BAT_OPTS" 
     else
         forgit::ignore::get $args
     end

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -234,13 +234,17 @@ if test -z "$FORGIT_GI_TEMPLATES"
     set -x FORGIT_GI_TEMPLATES $FORGIT_GI_REPO_LOCAL/templates
 end
 
+if test -z "FORGIT_BAT_OPTION"
+    set -x FORGIT_BAT_OPTION --color=always
+end
+
 function forgit::ignore
     if test -d "$FORGIT_GI_REPO_LOCAL"
         forgit::ignore::update
     end
 
     # https://github.com/sharkdp/bat.git
-    type -q bat > /dev/null 2>&1 && set cat 'bat -l gitignore --color=always' || set cat "cat"
+    type -q bat > /dev/null 2>&1 && set cat 'bat -l gitignore '"${FORGIT_BAT_OPTION}" || set cat "cat"
     set cmd "$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
@@ -260,7 +264,7 @@ function forgit::ignore
      end
 
     if type -q bat > /dev/null 2>&1
-        forgit::ignore::get $args | bat -l gitignore
+        forgit::ignore::get $args | bat -l gitignore "${FORGIT_BAT_OPTION}" 
     else
         forgit::ignore::get $args
     end

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -234,8 +234,8 @@ if test -z "$FORGIT_GI_TEMPLATES"
     set -x FORGIT_GI_TEMPLATES $FORGIT_GI_REPO_LOCAL/templates
 end
 
-if test -z "FORGIT_BAT_OPTS"
-    set -x FORGIT_BAT_OPTS --color=always
+if test -z "FORGIT_IGNORE_PAGER"
+    set -x FORGIT_IGNORE_PAGER bat -l gitignore --color=always
 end
 
 function forgit::ignore
@@ -244,7 +244,7 @@ function forgit::ignore
     end
 
     # https://github.com/sharkdp/bat.git
-    type -q bat > /dev/null 2>&1 && set cat 'bat -l gitignore '"$FORGIT_BAT_OPTS" || set cat "cat"
+    type -q bat > /dev/null 2>&1 && set cat $FORGIT_IGNORE_PAGER || set cat "cat"
     set cmd "$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
@@ -264,7 +264,7 @@ function forgit::ignore
      end
 
     if type -q bat > /dev/null 2>&1
-        forgit::ignore::get $args | bat -l gitignore "$FORGIT_BAT_OPTS" 
+        forgit::ignore::get $args | $FORGIT_IGNORE_PAGER 
     else
         forgit::ignore::get $args
     end

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -166,13 +166,13 @@ forgit::cherry::pick() {
 export FORGIT_GI_REPO_REMOTE=${FORGIT_GI_REPO_REMOTE:-https://github.com/dvcs/gitignore}
 export FORGIT_GI_REPO_LOCAL=${FORGIT_GI_REPO_LOCAL:-~/.forgit/gi/repos/dvcs/gitignore}
 export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
-export FORGIT_BAT_OPTS=${FORGIT_BAT_OPTION:---color=always}
+export FORGIT_IGNORE_PAGER=${FORGIT_IGNORE_PAGER:-bat -l gitignore --color=always}
 
 forgit::ignore() {
     [ -d "$FORGIT_GI_REPO_LOCAL" ] || forgit::ignore::update
     local IFS cmd args cat opts
     # https://github.com/sharkdp/bat.git
-    hash bat &>/dev/null && cat='bat -l gitignore '"${FORGIT_BAT_OPTS}" || cat="cat"
+    hash bat &>/dev/null && cat="${FORGIT_IGNORE_PAGER}" || cat="cat"
     cmd="$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -185,7 +185,7 @@ forgit::ignore() {
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     if hash bat &>/dev/null; then
-      forgit::ignore::get ${args[@]} | eval bat -l gitignore "$FORGIT_BAT_OPTS"
+      forgit::ignore::get ${args[@]} | eval "${FORGIT_IGNORE_PAGER}"
     else
         forgit::ignore::get ${args[@]}
     fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -166,12 +166,13 @@ forgit::cherry::pick() {
 export FORGIT_GI_REPO_REMOTE=${FORGIT_GI_REPO_REMOTE:-https://github.com/dvcs/gitignore}
 export FORGIT_GI_REPO_LOCAL=${FORGIT_GI_REPO_LOCAL:-~/.forgit/gi/repos/dvcs/gitignore}
 export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
+export FORGIT_BAT_OPTION=${FORGIT_BAT_OPTION:---color=always}
 
 forgit::ignore() {
     [ -d "$FORGIT_GI_REPO_LOCAL" ] || forgit::ignore::update
     local IFS cmd args cat opts
     # https://github.com/sharkdp/bat.git
-    hash bat &>/dev/null && cat='bat -l gitignore --color=always' || cat="cat"
+    hash bat &>/dev/null && cat='bat -l gitignore '"${FORGIT_BAT_OPTION}" || cat="cat"
     cmd="$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -184,7 +185,7 @@ forgit::ignore() {
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     if hash bat &>/dev/null; then
-        forgit::ignore::get ${args[@]} | bat -l gitignore
+        forgit::ignore::get ${args[@]} | bat -l gitignore "${FORGIT_BAT_OPTION}"
     else
         forgit::ignore::get ${args[@]}
     fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -166,13 +166,13 @@ forgit::cherry::pick() {
 export FORGIT_GI_REPO_REMOTE=${FORGIT_GI_REPO_REMOTE:-https://github.com/dvcs/gitignore}
 export FORGIT_GI_REPO_LOCAL=${FORGIT_GI_REPO_LOCAL:-~/.forgit/gi/repos/dvcs/gitignore}
 export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
-export FORGIT_BAT_OPTION=${FORGIT_BAT_OPTION:---color=always}
+export FORGIT_BAT_OPTS=${FORGIT_BAT_OPTION:---color=always}
 
 forgit::ignore() {
     [ -d "$FORGIT_GI_REPO_LOCAL" ] || forgit::ignore::update
     local IFS cmd args cat opts
     # https://github.com/sharkdp/bat.git
-    hash bat &>/dev/null && cat='bat -l gitignore '"${FORGIT_BAT_OPTION}" || cat="cat"
+    hash bat &>/dev/null && cat='bat -l gitignore '"${FORGIT_BAT_OPTS}" || cat="cat"
     cmd="$cat $FORGIT_GI_TEMPLATES/{2}{,.gitignore} 2>/dev/null"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -185,7 +185,7 @@ forgit::ignore() {
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     if hash bat &>/dev/null; then
-      forgit::ignore::get ${args[@]} | eval bat -l gitignore "$FORGIT_BAT_OPTION"
+      forgit::ignore::get ${args[@]} | eval bat -l gitignore "$FORGIT_BAT_OPTS"
     else
         forgit::ignore::get ${args[@]}
     fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -181,11 +181,11 @@ forgit::ignore() {
     "
     # shellcheck disable=SC2206,2207
     IFS=$'\n' args=($@) && [[ $# -eq 0 ]] && args=($(forgit::ignore::list | nl -nrn -w4 -s'  ' |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd" |awk '{print $2}'))
+        FZF_DEFAULT_OPTS="$opts" fzf --preview="eval $cmd" | awk '{print $2}'))
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     if hash bat &>/dev/null; then
-        forgit::ignore::get ${args[@]} | bat -l gitignore "${FORGIT_BAT_OPTION}"
+      forgit::ignore::get ${args[@]} | eval bat -l gitignore "$FORGIT_BAT_OPTION"
     else
         forgit::ignore::get ${args[@]}
     fi


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->
before the default option for bat where just `--color=always`, but now if FORGIT_BAT_OPTION is set it will use add the value of the variable to bat command.
for me, I want to use the following option to bat : `-pp --color=always --theme "Monokai Extended Origin"`
which I can use by setting the following in my zshrc : 
`export FORGIT_BAT_OPTION='-pp --color=always --theme="Monokai Extended Origin"'`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh 
    - [x] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
