### PR TITLE
FORGIT_GI_REPO_LOCAL and XDG

### DIFF
--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -227,7 +227,11 @@ if test -z "$FORGIT_GI_REPO_REMOTE"
 end
 
 if test -z "$FORGIT_GI_REPO_LOCAL"
-    set -x FORGIT_GI_REPO_LOCAL ~/.forgit/gi/repos/dvcs/gitignore
+    if test -z "XDG_CACHE_HOME"
+        set -x FORGIT_GI_REPO_LOCAL $XDG_CACHE_HOME/.forgit/gi/repos/dvcs/gitignore
+    else
+        set -x FORGIT_GI_REPO_LOCAL ~/.forgit/gi/repos/dvcs/gitignore
+    end
 end
 
 if test -z "$FORGIT_GI_TEMPLATES"

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -227,7 +227,7 @@ if test -z "$FORGIT_GI_REPO_REMOTE"
 end
 
 if test -z "$FORGIT_GI_REPO_LOCAL"
-    if test -z "XDG_CACHE_HOME"
+    if test "XDG_CACHE_HOME"
         set -x FORGIT_GI_REPO_LOCAL $XDG_CACHE_HOME/.forgit/gi/repos/dvcs/gitignore
     else
         set -x FORGIT_GI_REPO_LOCAL ~/.forgit/gi/repos/dvcs/gitignore

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -164,7 +164,7 @@ forgit::cherry::pick() {
 
 # git ignore generator
 export FORGIT_GI_REPO_REMOTE=${FORGIT_GI_REPO_REMOTE:-https://github.com/dvcs/gitignore}
-export FORGIT_GI_REPO_LOCAL=${FORGIT_GI_REPO_LOCAL:-~/.forgit/gi/repos/dvcs/gitignore}
+export FORGIT_GI_REPO_LOCAL="${FORGIT_GI_REPO_LOCAL:-${XDG_CACHE_HOME:-~/}}/.forgit/gi/repos/dvcs/gitignore"
 export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
 
 forgit::ignore() {


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

if FORGIT_GI_REPO_LOCAL is not already declared, use XDG_CACHE_HOME/.forgit/gi/repos/dvcs/gitignore if declared, and if not declared too, use the the fallback path which is ~/.forgit/gi/repos/dvcs/gitignore

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh 
    - [x] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
