### PR TITLE
fixed fish if .forgit wasn't already existing

### DIFF
--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -235,7 +235,7 @@ if test -z "$FORGIT_GI_TEMPLATES"
 end
 
 function forgit::ignore
-    if test -d "$FORGIT_GI_REPO_LOCAL"
+    if ! test -d "$FORGIT_GI_REPO_LOCAL"
         forgit::ignore::update
     end
 

--- a/forgit.plugin.fish
+++ b/forgit.plugin.fish
@@ -235,7 +235,7 @@ if test -z "$FORGIT_GI_TEMPLATES"
 end
 
 function forgit::ignore
-    if ! test -d "$FORGIT_GI_REPO_LOCAL"
+    if not test -d "$FORGIT_GI_REPO_LOCAL"
         forgit::ignore::update
     end
 


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

when using forgit for the first time, the .forgit folder is not
created. forgit::ignore::update, which git glone the repo, was executed
only if the folder existed, so now it execute only if the .forgit don't
exist.

also, there some weird things in the logic with forgit::ignore::update,
some part of the code it not running in any case, since the if test -d
in the fonction is called in a fonction which is called only if the
folder don't exist, or i miss something ?

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh 
    - [x] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
