### PR TITLE
Fix forgit::diff's fzf execute because of undefined $cmd

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -69,13 +69,12 @@ function forgit::diff -d "git diff viewer"
     end
 
     set repo (git rev-parse --show-toplevel)
+    set cmd "echo {} |sed 's/.*]  //' | xargs -I% git diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($cmd |env LESS='-r' less)\"
         $FORGIT_DIFF_FZF_OPTS
     "
-
-    set cmd "echo {} |sed 's/.*]  //' | xargs -I% git diff --color=always $commit -- '$repo/%' | $forgit_diff_pager"
 
     eval "git diff --name-only $commit -- $files*| sed -E 's/^(.)[[:space:]]+(.*)\$/[\1]  \2/'" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 end


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description
This pull request aims to fix a bug I had with fish and using forgit::diff
$cmd was not defined at the time opts get defined resulting in the following error : 
```
fish: Expected a command, but instead found a pipe
 |env LESS='-R' less
 ^
```
The fix is just about moving cmd definition before opts and after repo.
I'm using the fix and seems fine.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh 
    - [x] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
