### PR TITLE
Implement git-checkout to switch branches in a repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ source (curl -sSL git.io/forgit-fish | psub)
 
 - **Interactive `git rebase -i` selector** (`grb`)
 
+- **Interactive `git checkout` selector** (`gcb`)
+
 ### ⌨  Keybinds
 
 | Key                                           | Action                    |
@@ -120,6 +122,7 @@ forgit_clean=gclean
 forgit_stash_show=gss
 forgit_cherry_pick=gcp
 forgit_rebase=grb
+forgit_checkout=gcb
 ```
 
 Forgit will use the default configured pager from git (`core.pager`,
@@ -148,17 +151,18 @@ FORGIT_FZF_DEFAULT_OPTS="
 
 Customizing fzf options for each command individually is also supported:
 
-| Command  | Option                       |
-|----------|------------------------------|
-| `ga`     | `FORGIT_ADD_FZF_OPTS`        |
-| `glo`    | `FORGIT_LOG_FZF_OPTS`        |
-| `gi`     | `FORGIT_IGNORE_FZF_OPTS`     |
-| `gd`     | `FORGIT_DIFF_FZF_OPTS`       |
-| `grh`    | `FORGIT_RESET_HEAD_FZF_OPTS` |
-| `gcf`    | `FORGIT_CHECKOUT_FZF_OPTS`   |
-| `gss`    | `FORGIT_STASH_FZF_OPTS`      |
-| `gclean` | `FORGIT_CLEAN_FZF_OPTS`      |
-| `grb`    | `FORGIT_REBASE_FZF_OPTS`     |
+| Command  | Option                            |
+|----------|-----------------------------------|
+| `ga`     | `FORGIT_ADD_FZF_OPTS`             |
+| `glo`    | `FORGIT_LOG_FZF_OPTS`             |
+| `gi`     | `FORGIT_IGNORE_FZF_OPTS`          |
+| `gd`     | `FORGIT_DIFF_FZF_OPTS`            |
+| `grh`    | `FORGIT_RESET_HEAD_FZF_OPTS`      |
+| `gcf`    | `FORGIT_CHECKOUT_FZF_OPTS`        |
+| `gss`    | `FORGIT_STASH_FZF_OPTS`           |
+| `gclean` | `FORGIT_CLEAN_FZF_OPTS`           |
+| `grb`    | `FORGIT_REBASE_FZF_OPTS`          |
+| `gcb`    | `FORGIT_CHECKOUT_BRANCH_FZF_OPTS` |
 
 Complete loading order of fzf options is:
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -182,6 +182,19 @@ forgit::rebase() {
         xargs -I% git rebase -i %
 }
 
+forgit::checkout() {
+    forgit::inside_work_tree || return 1
+    local cmd preview opts
+    cmd="git branch --color=always --verbose --all --format=\"%(if:equals=HEAD)%(refname:strip=3)%(then)%(else)%(refname:short)%(end)\" $* $forgit_emojify | sed '/^$/d'"
+    preview="git log {} --graph --pretty=format:'%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset' --color=always --abbrev-commit --date=relative"
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        +s +m --tiebreak=index --ansi
+        $FORGIT_CHECKOUT_BRANCH_FZF_OPTS
+        "
+    eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" | xargs -I% git checkout %
+}
+
 # git ignore generator
 export FORGIT_GI_REPO_REMOTE=${FORGIT_GI_REPO_REMOTE:-https://github.com/dvcs/gitignore}
 export FORGIT_GI_REPO_LOCAL="${FORGIT_GI_REPO_LOCAL:-${XDG_CACHE_HOME:-$HOME/.cache}/forgit/gi/repos/dvcs/gitignore}"
@@ -254,6 +267,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_diff:-gd}"='forgit::diff'
     alias "${forgit_ignore:-gi}"='forgit::ignore'
     alias "${forgit_restore:-gcf}"='forgit::restore'
+    alias "${forgit_checkout:-gcb}"='forgit::checkout'
     alias "${forgit_clean:-gclean}"='forgit::clean'
     alias "${forgit_stash_show:-gss}"='forgit::stash::show'
     alias "${forgit_cherry_pick:-gcp}"='forgit::cherry::pick'


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

I added `gcb` which is used to list all the branches and checkout into
one of your choice. I believe this is a useful functionality especially
when a repo has too many branches to rememmber and lookup.

The preview contains the log tree from the selected branch.
I have removed keybinding for copy commit hash on gcb alias

Signed-off-by: b10n1k <jbonatakis@gmail.com>

#26
#101

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
