### PR TITLE
fix: Check for GIT_PAGER env

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ Forgit will use the default configured pager from git (`core.pager`,
 `pager.show`, `pager.diff`) but can be altered with the following environment
 variables:
 
-| Use case             | Option                | Fallbacks to                                 |
-| ------------         | -------------------   | -------------------------------------------- |
-| common pager         | `FORGIT_PAGER`        | `git config core.pager` _or_ `cat`           |
-| pager on `git show`  | `FORGIT_SHOW_PAGER`   | `git config pager.show` _or_ `$FORGIT_PAGER` |
-| pager on `git diff`  | `FORGIT_DIFF_PAGER`   | `git config pager.diff` _or_ `$FORGIT_PAGER` |
-| pager on `gitignore` | `FORGIT_IGNORE_PAGER` | `bat -l gitignore --color always` _or_ `cat` |
+| Use case             | Option                | Fallbacks to                                        |
+| ------------         | -------------------   | ----------------------------------------------------|
+| common pager         | `FORGIT_PAGER`        | `GIT_PAGER` _or_ `git config core.pager` _or_ `cat` |
+| pager on `git show`  | `FORGIT_SHOW_PAGER`   | `git config pager.show` _or_ `$FORGIT_PAGER`        |
+| pager on `git diff`  | `FORGIT_DIFF_PAGER`   | `git config pager.diff` _or_ `$FORGIT_PAGER`        |
+| pager on `gitignore` | `FORGIT_IGNORE_PAGER` | `bat -l gitignore --color always` _or_ `cat`        |
 
 You can add default fzf options for `forgit`, including keybinds, layout, etc.
 (No need to repeat the options already defined in `FZF_DEFAULT_OPTS`)

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -7,7 +7,14 @@ forgit::inside_work_tree() { git rev-parse --is-inside-work-tree >/dev/null; }
 # https://github.com/wfxr/emoji-cli
 hash emojify &>/dev/null && forgit_emojify='|emojify'
 
-forgit_pager=${FORGIT_PAGER:-$(git config core.pager || echo 'cat')}
+if [[ ! -z ${FORGIT_PAGER} ]]; then
+  forgit_pager=${FORGIT_PAGER}
+elif [[ ! -z ${GIT_PAGER} ]]; then
+  forgit_pager=${GIT_PAGER}
+else
+  forgit_pager=$(git config core.pager || echo 'cat')
+fi
+
 forgit_show_pager=${FORGIT_SHOW_PAGER:-$(git config pager.show || echo "$forgit_pager")}
 forgit_diff_pager=${FORGIT_DIFF_PAGER:-$(git config pager.diff || echo "$forgit_pager")}
 forgit_ignore_pager=${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -l gitignore --color=always' || echo 'cat')}


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [ x] I have performed a self-review of my code
- [ x] I have commented my code in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->
Currently, the `GIT_PAGER` environment variable is ignored. This deviated from the git configuration standard, as the environment variable has precedence over the `core.pager` property.

## Type of change

- [ x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ x] bash
    - [ x] zsh 
    - [ ] fish 
- OS
    - [ ] Linux
    - [ x] Mac OS X
    - [ ] Windows
    - [ ] Others:
