### PR TITLE
fix: improve compatibility for vim

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -165,7 +165,7 @@ forgit::cherry::pick() {
 
 forgit::rebase() {
     forgit::inside_work_tree || return 1
-    local cmd preview opts graph files
+    local cmd preview opts graph files commit
     graph=--graph
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
     cmd="git log $graph --color=always --format='%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset' $* $forgit_emojify"
@@ -177,9 +177,9 @@ forgit::rebase() {
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '\n' |${FORGIT_COPY_CMD:-pbcopy})\"
         $FORGIT_REBASE_FZF_OPTS
     "
-    eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
-        grep -Eo '[a-f0-9]+' | head -1 |
-        xargs -I% git rebase -i %
+    commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
+        grep -Eo '[a-f0-9]+' | head -1)
+    [[ -n "$commit" ]] && git rebase -i "$commit"
 }
 
 forgit::checkout::branch() {


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

For some reasons vim and xargs do not work well together (nvim does not have the problem).

So I rewrite the related code in a little more verbose way to improve compatibility for vim (and maybe some other terminal editors).

Related issue: #138 

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
