### PR TITLE
Add fixup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ source (curl -sSL git.io/forgit-fish | psub)
 
 - **Interactive `git rebase -i` selector** (`grb`)
 
+- **Interactive `git commit --fixup && git rebase -i --autosquash` selector** (`gfu`)
+
 - **Interactive `git checkout` selector** (`gcb`)
 
 ### ⌨  Keybinds
@@ -133,6 +135,7 @@ forgit_clean=gclean
 forgit_stash_show=gss
 forgit_cherry_pick=gcp
 forgit_rebase=grb
+forgit_fixup=gfu
 forgit_checkout_branch=gcb
 ```
 
@@ -178,6 +181,7 @@ Customizing fzf options for each command individually is also supported:
 | `gss`    | `FORGIT_STASH_FZF_OPTS`           |
 | `gclean` | `FORGIT_CLEAN_FZF_OPTS`           |
 | `grb`    | `FORGIT_REBASE_FZF_OPTS`          |
+| `gfu`    | `FORGIT_FIXUP_FZF_OPTS`           |
 | `gcb`    | `FORGIT_CHECKOUT_BRANCH_FZF_OPTS` |
 
 Complete loading order of fzf options is:

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -187,7 +187,7 @@ forgit::rebase() {
 forgit::fixup() {
     forgit::inside_work_tree || return 1
     git diff --cached --quiet && echo 'Nothing to fixup: there are no staged changes.' && return 1
-    local cmd preview opts graph files commit
+    local cmd preview opts graph files target_commit prev_commit
     graph=--graph
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
     cmd="git log $graph --color=always --format='$forgit_log_format' $* $forgit_emojify"
@@ -199,12 +199,19 @@ forgit::fixup() {
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]' |${FORGIT_COPY_CMD:-pbcopy})\"
         $FORGIT_FIXUP_FZF_OPTS
     "
-    commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
+    target_commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
         grep -Eo '[a-f0-9]+' | head -1)
-    [[ -n "$commit" ]] && git commit --fixup "$commit" && \
+    if [[ -n "$target_commit" ]] && git commit --fixup "$target_commit"; then
+        # "$commit~" is invalid when the commit is the first commit, but we can use "--root" instead
+        if [[ "$(git rev-parse "$target_commit")" == "$(git rev-list --max-parents=0 HEAD)" ]]; then
+            prev_commit="--root"
+        else
+            prev_commit="$commit~"
+        fi
         # rebase will fail if there are unstaged changes so --autostash is needed to temporarily stash them
         # GIT_SEQUENCE_EDITOR=: is needed to skip the editor
-        GIT_SEQUENCE_EDITOR=: git rebase --autostash -i --autosquash "$commit~1"
+        GIT_SEQUENCE_EDITOR=: git rebase --autostash -i --autosquash "$prev_commit"
+    fi
 
 }
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -203,8 +203,8 @@ forgit::fixup() {
         grep -Eo '[a-f0-9]+' | head -1)
     [[ -n "$commit" ]] && git commit --fixup "$commit" && \
         # rebase will fail if there are unstaged changes so --autostash is needed to temporarily stash them
-        # GIT_EDITOR=true is needed to skip the editor
-        GIT_EDITOR=true git rebase --autostash -i --autosquash "$commit~1"
+        # GIT_SEQUENCE_EDITOR=: is needed to skip the editor
+        GIT_SEQUENCE_EDITOR=: git rebase --autostash -i --autosquash "$commit~1"
 
 }
 


### PR DESCRIPTION
Signed-off-by: Ariel Davidov <arik.davidov@gmail.com>

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

A combination of fixup and autosquash is useful to fix any past commit.
However, using it manually is inconvenient (see: https://fle.github.io/git-tip-keep-your-branch-clean-with-fixup-and-autosquash.html).
Fixing the last commit is easy: `git commit --amend --no-edit`.
The new function makes fixing any commit as convenient as fixing the last commit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
