### PR TITLE
Bugfix: gd(git diff) for fish does not work with arguments

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -59,11 +59,11 @@ function forgit::log -d "git commit viewer"
 end
 
 ## git diff viewer
-function forgit::diff -d "git diff viewer" 
+function forgit::diff -d "git diff viewer"
     forgit::inside_work_tree || return 1
     if count $argv > /dev/null
-        if git rev-parse "$1" > /dev/null 2>&1
-            set commit "$1" && set files "$2"
+        if git rev-parse "$argv[1]" > /dev/null 2>&1
+            set commit "$argv[1]" && set files "$argv[2..]"
         else
             set files "$argv"
         end
@@ -228,7 +228,7 @@ function forgit::checkout::branch -d "git checkout branch selector" --argument-n
 
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m --tiebreak=index 
+        +s +m --tiebreak=index
         $FORGIT_CHECKOUT_BRANCH_FZF_OPTS
         "
     eval "$cmd" | env FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" | xargs -I% git checkout %


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [] I have commented my code in hard-to-understand areas
- [] I have made corresponding changes to the documentation

## Description

fish does not use $1 and $2 for arguments, instead it using $argv which is a array/list and to index $1, $argv[1] should be used.
I am not sure why this issue was not reported before. But I believe it has been there for a long time.

To test:

`gd branch_name `

It should works for both zsh and fish. But it only works for zsh ATM. Run command in fish, an error will be shown


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh 
    - [x] fish 
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
