### PR TITLE
Fix `gcb` alias in Fish

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -499,7 +499,7 @@ if test -z "$FORGIT_NO_ALIASES"
     end
 
     if test -n "$forgit_checkout_branch"
-        alias $forgit_branch 'forgit::checkout::branch'
+        alias $forgit_checkout_branch 'forgit::checkout::branch'
     else
         alias gcb 'forgit::checkout::branch'
     end


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

When defining a custom alias for the `gcb` (Git checkout branch) in alias, the custom alias is not registered; rather, `fish` will omit the following warning on start: `alias: Body cannot be empty`.

I think this is caused due to a typo between the variable that’s being tested for presence and the variable that’s later used for setting the alias.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh 
    - [x] fish 
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
