### PR TITLE
Proposal to fix the checkout branch when a local branch exists and contains slashes in its name

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -229,8 +229,16 @@ forgit::checkout::branch() {
         "
     branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" | awk '{print $1}')"
     [[ -z "$branch" ]] && return 1
+    
     # track the remote branch if possible
-    if ! git checkout --track "$branch" 2>/dev/null; then
+    if [[ "$branch" == "remotes/origin/"* ]]; then
+        if [[ -n $(git branch | grep -w "${branch#remotes/origin/}") ]]; then
+            # hack to force creating a new branch which tracks the remote if a local branch already exists
+            git checkout -b "track/${branch#remotes/origin/}" --track "$branch"
+        elif ! git checkout --track "$branch" 2>/dev/null; then
+            git checkout "$branch"
+        fi
+    else
         git checkout "$branch"
     fi
 }


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

The last change introduced in order to track a remote branch create a bug when the branch name contains slashes and the branch already exists locally.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh 
    - [ ] fish 
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
