### PR TITLE
feat: Add aliases for git diff staged and cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ You can change the default aliases by defining these variables below.
 ``` bash
 forgit_log=glo
 forgit_diff=gd
+forgit_diff_cached=gdca
+forgit_diff_staged=gds
 forgit_add=ga
 forgit_reset_head=grh
 forgit_ignore=gi

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -488,6 +488,18 @@ if test -z "$FORGIT_NO_ALIASES"
         alias gd 'forgit::diff'
     end
 
+    if test -n "$forgit_diff_cached"
+        alias $forgit_diff_cached 'forgit::diff'
+    else
+        alias gdca 'forgit::diff --cached'
+    end
+
+    if test -n "$forgit_diff_staged"
+        alias $forgit_diff_staged 'forgit::diff --staged'
+    else
+        alias gds 'forgit::diff --staged'
+    end
+
     if test -n "$forgit_ignore"
         alias $forgit_ignore 'forgit::ignore'
     else

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -331,6 +331,8 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_reset_head:-grh}"='forgit::reset::head'
     alias "${forgit_log:-glo}"='forgit::log'
     alias "${forgit_diff:-gd}"='forgit::diff'
+    alias "${forgit_diff_cached:-gdca}"='forgit::diff --cached'
+    alias "${forgit_diff_staged:-gds}"='forgit::diff --staged'
     alias "${forgit_ignore:-gi}"='forgit::ignore'
     alias "${forgit_checkout_file:-gcf}"='forgit::checkout::file'
     alias "${forgit_checkout_branch:-gcb}"='forgit::checkout::branch'


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Added aliases for `git diff --staged` and `git diff --cached`
## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [X] fish
- OS
    - [ ] Linux
    - [X] Mac OS X
    - [ ] Windows
    - [ ] Others:

Closes #174 