### PR TITLE
Fix glo string interpolation

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -29,7 +29,7 @@ forgit::log() {
     "
     graph=--graph
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
-    eval "git log $graph --color=always --format='$forgit_log_format' $* $forgit_emojify" |
+    eval "git log $graph --color=always --format="$forgit_log_format" $* $forgit_emojify" |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 


### PR DESCRIPTION
## Description


<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Custom git log options do not work not. This is because wrong quotes in forgit::log() function.

## Type of change

- [ x] Bug fix

## Test environment

- Shell
    - [x ] zsh
- OS
    - [x ] Linux