### PR TITLE
Implemented git checkout tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ source (curl -sSL git.io/forgit-fish | psub)
 
 - **Interactive `git checkout <branch>` selector** (`gcb`)
 
+- **Interactive `git checkout <tag>` selector** (`gct`)
+
 - **Interactive `git checkout <commit>` selector** (`gco`)
 
 - **Interactive `git stash` viewer** (`gss`)
@@ -136,6 +138,7 @@ forgit_reset_head=grh
 forgit_ignore=gi
 forgit_checkout_file=gcf
 forgit_checkout_branch=gcb
+forgit_checkout_tag=gct
 forgit_checkout_commit=gco
 forgit_clean=gclean
 forgit_stash_show=gss
@@ -215,6 +218,7 @@ Customizing fzf options for each command individually is also supported:
 | `grh`    | `FORGIT_RESET_HEAD_FZF_OPTS`      |
 | `gcf`    | `FORGIT_CHECKOUT_FILE_FZF_OPTS`   |
 | `gcb`    | `FORGIT_CHECKOUT_BRANCH_FZF_OPTS` |
+| `gct`    | `FORGIT_CHECKOUT_TAG_FZF_OPTS`    |
 | `gco`    | `FORGIT_CHECKOUT_COMMIT_FZF_OPTS` |
 | `gss`    | `FORGIT_STASH_FZF_OPTS`           |
 | `gclean` | `FORGIT_CLEAN_FZF_OPTS`           |

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -243,6 +243,23 @@ forgit::checkout::branch() {
     fi
 }
 
+# git checkout-tag selector
+forgit::checkout::tag() {
+    forgit::inside_work_tree || return 1
+    [[ $# -ne 0 ]] && { git checkout "$@"; return $?; }
+    local cmd opts preview
+    cmd="git tag -l --sort=-v:refname"
+    preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        +s +m --tiebreak=index
+        $FORGIT_CHECKOUT_TAG_FZF_OPTS
+    "
+    tag="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")"
+    [[ -z "$tag" ]] && return 1
+    git checkout "$tag"
+}
+
 # git checkout-commit selector
 forgit::checkout::commit() {
     forgit::inside_work_tree || return 1
@@ -335,6 +352,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_checkout_file:-gcf}"='forgit::checkout::file'
     alias "${forgit_checkout_branch:-gcb}"='forgit::checkout::branch'
     alias "${forgit_checkout_commit:-gco}"='forgit::checkout::commit'
+    alias "${forgit_checkout_tag:-gct}"='forgit::checkout::tag'
     alias "${forgit_clean:-gclean}"='forgit::clean'
     alias "${forgit_stash_show:-gss}"='forgit::stash::show'
     alias "${forgit_cherry_pick:-gcp}"='forgit::cherry::pick'


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

I've added `gct` which is very similar to `gcb`, except that it operates on tags instead of branches. The sorting of tags treats names as versions.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
