### PR TITLE
Add missing support for `FORGIT_GLO_FORMAT`

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -17,7 +17,7 @@ forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Cres
 # git commit viewer
 forgit::log() {
     forgit::inside_work_tree || return 1
-    local cmd opts graph files
+    local cmd opts graph files log_format
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
     cmd="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
     opts="
@@ -29,7 +29,8 @@ forgit::log() {
     "
     graph=--graph
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
-    eval "git log $graph --color=always --format='$forgit_log_format' $* $forgit_emojify" |
+    log_format=${FORGIT_GLO_FORMAT:-$forgit_log_format}
+    eval "git log $graph --color=always --format='$log_format' $* $forgit_emojify" |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
 }
 


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

`FORGIT_GLO_FORMAT` appears in the documentation, but it was not anywhere to be found on the code itself.
This PR just adds this missing feature.

Now, before anyone mentions `FORGIT_LOG_FORMAT` - this global variable needs to be set **before** forgit is first loaded and cannot be changed during an active session. For me it means to put it in `~/.zshenv` which gets loaded before anything else, and I consider this to be less than ideal.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
