### PR TITLE
Make fzf '--preview' argument overridable in environment

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -25,13 +25,14 @@ forgit::log() {
         +s +m --tiebreak=index
         --bind=\"enter:execute($cmd | LESS='-r' less)\"
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]' |${FORGIT_COPY_CMD:-pbcopy})\"
+        --preview=\"$cmd\"
         $FORGIT_LOG_FZF_OPTS
     "
     graph=--graph
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
     log_format=${FORGIT_GLO_FORMAT:-$forgit_log_format}
     eval "git log $graph --color=always --format='$log_format' $* $forgit_emojify" |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
+        FZF_DEFAULT_OPTS="$opts" fzf
 }
 
 # git diff viewer
@@ -54,11 +55,12 @@ forgit::diff() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($cmd |LESS='-r' less)\"
+        --preview=\"$cmd\"
         $FORGIT_DIFF_FZF_OPTS
     "
     eval "git diff --name-status $commits -- ${files[*]} | sed -E 's/^([[:alnum:]]+)[[:space:]]+(.*)$/[\1]\t\2/'" |
         sed 's/\t/  ->  /2' | expand -t 8 |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
+        FZF_DEFAULT_OPTS="$opts" fzf
 }
 
 # git add selector
@@ -87,12 +89,13 @@ forgit::add() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
+        --preview=\"$preview\"
         $FORGIT_ADD_FZF_OPTS
     "
     files=$(git -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
+        FZF_DEFAULT_OPTS="$opts" fzf |
         sh -c "$extract")
     [[ -n "$files" ]] && echo "$files"| tr '\n' '\0' |xargs -0 -I% git add % && git status -su && return
     echo 'Nothing to add.'
@@ -106,9 +109,10 @@ forgit::reset::head() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
+        --preview=\"$cmd\"
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    files="$(git diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
+    files="$(git diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf)"
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD % && git status --short && return
     echo 'Nothing to unstage.'
 }
@@ -121,9 +125,10 @@ forgit::stash::show() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m -0 --tiebreak=index --bind=\"enter:execute($cmd | LESS='-r' less)\"
+        --preview=\"$cmd\"
         $FORGIT_STASH_FZF_OPTS
     "
-    git stash list | FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd"
+    git stash list | FZF_DEFAULT_OPTS="$opts" fzf
 }
 
 # git clean selector
@@ -149,10 +154,11 @@ forgit::cherry::pick() {
     preview="echo {1} | xargs -I% git show --color=always % | $forgit_show_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
+        --preview=\"$preview\"
         -m -0
     "
     git cherry "$base" "$target" --abbrev -v | cut -d ' ' -f2- |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" | cut -d' ' -f1 |
+        FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f1 |
         xargs -I% git cherry-pick %
 }
 
@@ -168,9 +174,10 @@ forgit::rebase() {
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]' |${FORGIT_COPY_CMD:-pbcopy})\"
+        --preview=\"$preview\"
         $FORGIT_REBASE_FZF_OPTS
     "
-    commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
+    commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf |
         grep -Eo '[a-f0-9]+' | head -1)
     [[ -n "$commit" ]] && git rebase -i "$commit"
 }
@@ -188,9 +195,10 @@ forgit::fixup() {
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]' |${FORGIT_COPY_CMD:-pbcopy})\"
+        --preview=\"$preview\"
         $FORGIT_FIXUP_FZF_OPTS
     "
-    target_commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" |
+    target_commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf |
         grep -Eo '[a-f0-9]+' | head -1)
     if [[ -n "$target_commit" ]] && git commit --fixup "$target_commit"; then
         # "$target_commit~" is invalid when the commit is the first commit, but we can use "--root" instead
@@ -215,9 +223,10 @@ forgit::checkout::file() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
+        --preview=\"$cmd\"
         $FORGIT_CHECKOUT_FILE_FZF_OPTS
     "
-    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd")"
+    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf)"
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git checkout %
 }
 
@@ -231,9 +240,10 @@ forgit::checkout::branch() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index --header-lines=1
+        --preview=\"$preview\"
         $FORGIT_CHECKOUT_BRANCH_FZF_OPTS
         "
-    branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" | awk '{print $1}')"
+    branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')"
     [[ -z "$branch" ]] && return 1
 
     # track the remote branch if possible
@@ -259,9 +269,10 @@ forgit::checkout::tag() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
+        --preview=\"$preview\"
         $FORGIT_CHECKOUT_TAG_FZF_OPTS
     "
-    tag="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")"
+    tag="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf)"
     [[ -z "$tag" ]] && return 1
     git checkout "$tag"
 }
@@ -276,12 +287,13 @@ forgit::checkout::commit() {
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]' |${FORGIT_COPY_CMD:-pbcopy})\"
+        --preview=\"$cmd\"
         $FORGIT_COMMIT_FZF_OPTS
     "
     graph=--graph
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
     eval "git log $graph --color=always --format='$forgit_log_format' $forgit_emojify" |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$cmd" |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git checkout % --
+        FZF_DEFAULT_OPTS="$opts" fzf |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git checkout % --
 }
 
 # git revert-commit selector
@@ -318,11 +330,12 @@ forgit::ignore() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m --preview-window='right:70%'
+        --preview=\"eval $cmd\"
         $FORGIT_IGNORE_FZF_OPTS
     "
     # shellcheck disable=SC2206,2207
     IFS=$'\n' args=($@) && [[ $# -eq 0 ]] && args=($(forgit::ignore::list | nl -nrn -w4 -s'  ' |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="eval $cmd" | awk '{print $2}'))
+        FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}'))
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     forgit::ignore::get ${args[@]}


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [n/a] I have commented my code in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation

## Description

Arguments to fzf are passed via the `FZF_DEFAULT_OPTS` environment
variable, which can be overridden by a dedicated `FORGIT_<cmd>_FZF_OPTS`
variable for each command separately. The `--preview` argument, however,
was excluded from this mechanism and hard-coded to the fzf call, so that
there was no chance overriding it.
This patch moves the passing of this argument to the `FZF_DEFAULT_OPTS`
variable for all commands, so that it can be overridden as well.

Fixes #185

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
