### PR TITLE
Fixed: grc fails when commit is preceded by anything else than '* '

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -300,7 +300,7 @@ forgit::checkout::commit() {
 forgit::revert::commit() {
     forgit::inside_work_tree || return 1
     [[ $# -ne 0 ]] && { git revert "$@"; return $?; }
-    local cmd opts files preview commits
+    local cmd opts files preview commits IFS
     cmd="git log --graph --color=always --format='$forgit_log_format' $* $forgit_emojify"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -309,15 +309,14 @@ forgit::revert::commit() {
     "
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
     preview="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
-    commits="$(eval "$cmd" |
+    # shellcheck disable=2207
+    IFS=$'\n' commits=($(eval "$cmd" |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" -m |
-        sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/' |
-        tr $'\n' ' ')"
-    if [[ "$commits" == *[![:space:]]* ]]; then
-        git revert $(echo "$commits")
-    else
-        return 1
-    fi
+        sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/'))
+    [ ${#commits[@]} -eq 0 ] && return 1
+    for commit in "${commits[@]}"; do
+        git revert "$commit"
+    done
 }
 
 # git ignore generator

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -314,7 +314,7 @@ forgit::revert::commit() {
         sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/' |
         tr $'\n' ' ')"
     if [[ "$commits" == *[![:space:]]* ]]; then
-        eval "git revert $commits"
+        git revert $(echo "$commits")
     else
         return 1
     fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -311,11 +311,13 @@ forgit::revert::commit() {
     preview="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
     commits="$(eval "$cmd" |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" -m |
-        grep -Eo '^\*\s[a-f0-9]+' |
-        cut -c 3- |
+        sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/' |
         tr $'\n' ' ')"
-    [[ -z "$commits" ]] && return 1
-    eval "git revert $commits"
+    if [[ "$commits" == *[![:space:]]* ]]; then
+        eval "git revert $commits"
+    else
+        return 1
+    fi
 }
 
 # git ignore generator


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

Before this commit, the regex for extracting the commit hash when using `grc` assumed that each line starts with '* '. This is not the case when your commit history contains merges that were not squashed and looks more like this 

```
*   7bf6560 Merge branch 'test-branch' 4 days ago
|\  
| * c753f1c (test-branch) Test commit 5 4 days ago
| * d3c7c6d Test commit 4 4 days ago
* | 1869317 Test commit 6 4 days ago
|/  
* b344261 Test commit 3 3 weeks ago
```
In the example above, selecting the line `| * c753f1c (test-branch) Test commit 5 4 days ago` would fail to revert the commit. This is now fixed.
Note: The fish implementation does not seem to have this issue.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
