### PR TITLE
Fix gcb problems with verbosity and collation

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -257,7 +257,7 @@ function forgit::checkout::branch -d "git checkout branch selector" --argument-n
         $FORGIT_CHECKOUT_BRANCH_FZF_OPTS
         "
 
-    set cmd "git branch --color=always --verbose --all | sort -k1.1,1.1 -r"
+    set cmd "git branch --color=always --all | sort -k1.1,1.1 -r"
     set branch (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
 
     test -z "$branch" && return 1

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -257,7 +257,7 @@ function forgit::checkout::branch -d "git checkout branch selector" --argument-n
         $FORGIT_CHECKOUT_BRANCH_FZF_OPTS
         "
 
-    set cmd "git branch --color=always --all | sort -k1.1,1.1 -r"
+    set cmd "git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
     set branch (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
 
     test -z "$branch" && return 1

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -235,7 +235,7 @@ forgit::checkout::branch() {
     forgit::inside_work_tree || return 1
     [[ $# -ne 0 ]] && { git checkout -b "$@"; return $?; }
     local cmd preview opts branch
-    cmd="git branch --color=always --verbose --all | sort -k1.1,1.1 -r"
+    cmd="git branch --color=always --all | sort -k1.1,1.1 -r"
     preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -235,7 +235,7 @@ forgit::checkout::branch() {
     forgit::inside_work_tree || return 1
     [[ $# -ne 0 ]] && { git checkout -b "$@"; return $?; }
     local cmd preview opts branch
-    cmd="git branch --color=always --all | sort -k1.1,1.1 -r"
+    cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
     preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

This PR fixes a couple of issues in checkout::branch (the gcb function) related to the verbosity of the output and the ordering of the branches.

Fixes #167 
Fixes #180 
Fixes #195 

### Before

Instead of the HEAD, a wrong branch (main in the screenshot) is used as a header line (this behavior depends on the locales configuration, `LC_COLLATE="es_ES.UTF-8"` in this example). Furthermore, the list contains the last commit hash and subject, complicating the selection of the right one with fzf:

![2022-04-06_17-21](https://user-images.githubusercontent.com/12902878/162010632-04d2d735-1c57-4bb6-86a0-0c161456b3ad.png)

### After

The right line is used as a header (the current HEAD, which starts with an asterisk), and the list shows just the branch names:

![2022-04-06_17-23](https://user-images.githubusercontent.com/12902878/162010691-571639b6-fba8-47fa-a82f-1f7c901434fb.png)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
