### PR TITLE
fix: `forgit::rebase` not working in fish

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -374,7 +374,7 @@ function forgit::rebase -d "git rebase"
     else
         set graph ""
     end
-    set preview "git log $graph --color=always --format='$forgit_log_format' $argv $forgit_emojify"
+    set cmd "git log $graph --color=always --format='$forgit_log_format' $argv $forgit_emojify"
 
     set files (echo $argv | sed -nE 's/.* -- (.*)/\1/p')
     set preview "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
@@ -392,7 +392,7 @@ function forgit::rebase -d "git rebase"
         --preview=\"$preview\"
         $FORGIT_REBASE_FZF_OPTS
     "
-    set commit (eval "$preview" | FZF_DEFAULT_OPTS="$opts" fzf |
+    set commit (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf |
         grep -Eo '[a-f0-9]+' | head -1)
 
     if test $commit


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:

https://github.com/wfxr/forgit/commit/d0b3cfca33348f51a6494e5bb0c9c01934bc29bc broke `grb` i.e. `forgot::rebase` in fish.  