### PR TITLE
Adding support for git branch delete method in fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ source (curl -sSL git.io/forgit-fish | psub)
 
 - **Interactive `git checkout <branch>` selector** (`gcb`)
 
+- **Interactive `git branch -D <branch>` selector** (`gbd`)
+
 - **Interactive `git checkout <tag>` selector** (`gct`)
 
 - **Interactive `git checkout <commit>` selector** (`gco`)
@@ -140,6 +142,7 @@ forgit_reset_head=grh
 forgit_ignore=gi
 forgit_checkout_file=gcf
 forgit_checkout_branch=gcb
+forgit_branch_delet=gbd
 forgit_checkout_tag=gct
 forgit_checkout_commit=gco
 forgit_revert_commit=grc
@@ -221,6 +224,7 @@ Customizing fzf options for each command individually is also supported:
 | `grh`    | `FORGIT_RESET_HEAD_FZF_OPTS`      |
 | `gcf`    | `FORGIT_CHECKOUT_FILE_FZF_OPTS`   |
 | `gcb`    | `FORGIT_CHECKOUT_BRANCH_FZF_OPTS` |
+| `gbd`    | `FORGIT_BRANCH_DELETE_FZF_OPTS`   |
 | `gct`    | `FORGIT_CHECKOUT_TAG_FZF_OPTS`    |
 | `gco`    | `FORGIT_CHECKOUT_COMMIT_FZF_OPTS` |
 | `grc`    | `FORGIT_REVERT_COMMIT_OPTS`       |

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -249,7 +249,7 @@ function forgit::branch::delete -d "git checkout branch deleter"
         $FORGIT_BRANCH_DELETE_FZF_OPTS
         "
 
-    set cmd "git branch --color=always --verbose --all | sort -k1.1,1.1 -r"
+    set cmd "git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
     set branches (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
 
     if test -n "$branches"

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -237,6 +237,31 @@ function forgit::checkout::commit -d "git checkout commit selector" --argument-n
         FZF_DEFAULT_OPTS="$opts" fzf  | grep -Eo '[a-f0-9]+' | head -1 | xargs -I% git checkout % --
 end
 
+function forgit::branch::delete -d "git checkout branch deleter"
+    forgit::inside_work_tree || return 1
+
+    set preview "git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+
+    set opts "
+        $FORGIT_FZF_DEFAULT_OPTS
+        +s --multi --tiebreak=index --header-lines=1
+        --preview=\"$preview\"
+        $FORGIT_BRANCH_DELETE_FZF_OPTS
+        "
+
+    set cmd "git branch --color=always --verbose --all | sort -k1.1,1.1 -r"
+    set branches (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
+
+    if test -n "$branches"
+        for branch in $branches
+            echo $branch | tr '\n' '\0' | xargs -I{} -0 git branch -D {}
+        end
+        git status --short
+        return
+    end
+end
+
+
 
 function forgit::checkout::branch -d "git checkout branch selector" --argument-names 'input_branch_name'
     forgit::inside_work_tree || return 1
@@ -566,6 +591,13 @@ if test -z "$FORGIT_NO_ALIASES"
     else
         alias gcb 'forgit::checkout::branch'
     end
+
+    if test -n "$forgit_branch_delete"
+        alias $forgit_branch_delete 'forgit::branch::delete'
+    else
+        alias gbd 'forgit::branch::delete'
+    end
+
 
     if test -n "$forgit_clean"
         alias $forgit_clean 'forgit::clean'

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -249,7 +249,7 @@ function forgit::branch::delete -d "git checkout branch deleter"
         $FORGIT_BRANCH_DELETE_FZF_OPTS
         "
 
-    set cmd "git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
+    set cmd "git branch --color=always | LC_ALL=C sort -k1.1,1.1 -rs"
     set branches (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
 
     if test -n "$branches"

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -296,6 +296,23 @@ forgit::checkout::commit() {
         FZF_DEFAULT_OPTS="$opts" fzf |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git checkout % --
 }
 
+forgit::branch::delete() {
+    forgit::inside_work_tree || return 1
+    local preview opts cmd branches
+    preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        +s --multi --tiebreak=index --header-lines=1
+        --preview=\"$preview\"
+        $FORGIT_BRANCH_DELETE_FZF_OPTS
+    "
+
+    cmd="git branch --color=always | LC_ALL=C sort -k1.1,1.1 -rs"
+    branches=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
+    echo -n "$branches" | tr '\n' '\0' | xargs -I{} -0 git branch -D {}
+}
+
 # git revert-commit selector
 forgit::revert::commit() {
     forgit::inside_work_tree || return 1
@@ -394,6 +411,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_checkout_file:-gcf}"='forgit::checkout::file'
     alias "${forgit_checkout_branch:-gcb}"='forgit::checkout::branch'
     alias "${forgit_checkout_commit:-gco}"='forgit::checkout::commit'
+    alias "${forgit_branch_delete:-gbd}"='forgit::branch::delete'
     alias "${forgit_revert_commit:-grc}"='forgit::revert::commit'
     alias "${forgit_checkout_tag:-gct}"='forgit::checkout::tag'
     alias "${forgit_clean:-gclean}"='forgit::clean'


### PR DESCRIPTION
Added `gbd` in fish. 

I often find that I end up with a bunch of stale branches, and I end up deleting them by hand. 

This allows for a nice way to easily delete my old branches, in a `forgit` complient way.

**NEEDS DUPLICATION IN BASH BY @wfxr or others :) **

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] New feature


## Test environment

- Shell
    - [x] fish
- OS
    - [x] Mac OS X

