### PR TITLE
Do not include commit hash or message when fuzzy searching with 'gcb'

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -257,7 +257,7 @@ function forgit::checkout::branch -d "git checkout branch selector" --argument-n
         $FORGIT_CHECKOUT_BRANCH_FZF_OPTS
         "
 
-    set cmd "git branch --color=always --verbose --all | sort -k1.1,1.1 -r"
+    set cmd "git branch --color=always --all | sort -k1.1,1.1 -r"
     set branch (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
 
     test -z "$branch" && return 1

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -235,7 +235,7 @@ forgit::checkout::branch() {
     forgit::inside_work_tree || return 1
     [[ $# -ne 0 ]] && { git checkout -b "$@"; return $?; }
     local cmd preview opts branch
-    cmd="git branch --color=always --verbose --all | sort -k1.1,1.1 -r"
+    cmd="git branch --color=always --all | sort -k1.1,1.1 -r"
     preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

This removes the commit hash and message from the fuzzy search when searching with `gcb`. 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others: