### PR TITLE
Feature: Added interactive git blame

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ source (curl -sSL git.io/forgit-fish | psub)
 
 - **Interactive `git rebase -i` selector** (`grb`)
 
+- **Interactive `git blame` selector** (`gb`)
+
 - **Interactive `git commit --fixup && git rebase -i --autosquash` selector** (`gfu`)
 
 ### ⌨  Keybinds
@@ -150,6 +152,7 @@ forgit_clean=gclean
 forgit_stash_show=gss
 forgit_cherry_pick=gcp
 forgit_rebase=grb
+forgit_blame=gb
 forgit_fixup=gfu
 ```
 
@@ -190,13 +193,14 @@ Forgit will use the default configured pager from git (`core.pager`,
 `pager.show`, `pager.diff`) but can be altered with the following environment
 variables:
 
-| Use case             | Option                | Fallbacks to                                 |
-| ------------         | -------------------   | -------------------------------------------- |
-| common pager         | `FORGIT_PAGER`        | `git config core.pager` _or_ `cat`           |
-| pager on `git show`  | `FORGIT_SHOW_PAGER`   | `git config pager.show` _or_ `$FORGIT_PAGER` |
-| pager on `git diff`  | `FORGIT_DIFF_PAGER`   | `git config pager.diff` _or_ `$FORGIT_PAGER` |
-| pager on `gitignore` | `FORGIT_IGNORE_PAGER` | `bat -l gitignore --color always` _or_ `cat` |
-| git log format       | `FORGIT_GLO_FORMAT`   | `%C(auto)%h%d %s %C(black)%C(bold)%cr%reset` |
+| Use case             | Option                | Fallbacks to                                  |
+| ------------         | -------------------   | --------------------------------------------- |
+| common pager         | `FORGIT_PAGER`        | `git config core.pager` _or_ `cat`            |
+| pager on `git show`  | `FORGIT_SHOW_PAGER`   | `git config pager.show` _or_ `$FORGIT_PAGER`  |
+| pager on `git diff`  | `FORGIT_DIFF_PAGER`   | `git config pager.diff` _or_ `$FORGIT_PAGER`  |
+| pager on `git blame` | `FORGIT_BLAME_PAGER`  | `git config pager.blame` _or_ `$FORGIT_PAGER` |
+| pager on `gitignore` | `FORGIT_IGNORE_PAGER` | `bat -l gitignore --color always` _or_ `cat`  |
+| git log format       | `FORGIT_GLO_FORMAT`   | `%C(auto)%h%d %s %C(black)%C(bold)%cr%reset`  |
 
 #### fzf options
 
@@ -231,6 +235,7 @@ Customizing fzf options for each command individually is also supported:
 | `gss`    | `FORGIT_STASH_FZF_OPTS`           |
 | `gclean` | `FORGIT_CLEAN_FZF_OPTS`           |
 | `grb`    | `FORGIT_REBASE_FZF_OPTS`          |
+| `gb`     | `FORGIT_BLAME_FZF_OPTS`           |
 | `gfu`    | `FORGIT_FIXUP_FZF_OPTS`           |
 
 Complete loading order of fzf options is:

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -347,7 +347,13 @@ forgit::blame() {
         $FORGIT_BLAME_FZF_OPTS
     "
     flags=$(git rev-parse --flags "$@")
-    preview="git blame {1} --date=short $flags | $forgit_blame_pager"
+    preview="
+        if (git ls-files {} --error-unmatch) &>/dev/null; then
+            git blame {} --date=short $flags | $forgit_blame_pager
+        else
+            echo File not tracked
+        fi
+    "
     file=$(FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
     [[ -z "$file" ]] && return 1
     eval git blame "$file" "$flags"


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Works similar to the existing `gd`. Flags are passed on to the blame command, so you could do something like `gb --color-lines`.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [X] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
