### PR TITLE
Add FORGIT_CHERRY_PICK_FZF_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,9 @@ Customizing fzf options for each command individually is also supported:
 | `gss`    | `FORGIT_STASH_FZF_OPTS`           |
 | `gclean` | `FORGIT_CLEAN_FZF_OPTS`           |
 | `grb`    | `FORGIT_REBASE_FZF_OPTS`          |
-| `gbl`     | `FORGIT_BLAME_FZF_OPTS`          |
+| `gbl`    | `FORGIT_BLAME_FZF_OPTS`           |
 | `gfu`    | `FORGIT_FIXUP_FZF_OPTS`           |
+| `gcp`    | `FORGIT_CHERRY_PICK_FZF_OPTS`     |
 
 Complete loading order of fzf options is:
 

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -340,6 +340,7 @@ function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target'
         --preview=\"$preview\"
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
+        $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     echo $base
     echo $target

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -157,6 +157,7 @@ forgit::cherry::pick() {
         $FORGIT_FZF_DEFAULT_OPTS
         --preview=\"$preview\"
         -m -0
+        $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     git cherry "$base" "$target" --abbrev -v | cut -d ' ' -f2- |
         FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f1 |


### PR DESCRIPTION
The gcp (git cherry pick) command was the only command which did not
have a variable to set command-specific fzf options. Add the according
variable to source code and documentation.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
