### PR TITLE
Improve cherry-pick

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,9 @@ Customizing fzf options for each command individually is also supported:
 | `gss`    | `FORGIT_STASH_FZF_OPTS`           |
 | `gclean` | `FORGIT_CLEAN_FZF_OPTS`           |
 | `grb`    | `FORGIT_REBASE_FZF_OPTS`          |
-| `gbl`     | `FORGIT_BLAME_FZF_OPTS`          |
+| `gbl`    | `FORGIT_BLAME_FZF_OPTS`           |
 | `gfu`    | `FORGIT_FIXUP_FZF_OPTS`           |
+| `gcp`    | `FORGIT_CHERRY_PICK_FZF_OPTS`     |
 
 Complete loading order of fzf options is:
 

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -344,8 +344,8 @@ function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target'
     "
     echo $base
     echo $target
-    git cherry "$base" "$target" --abbrev -v | cut -d ' ' -f2- |
-        env FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f1 |
+    git cherry "$base" "$target" --abbrev -v |
+        env FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f2 |
         xargs -I% git cherry-pick %
 end
 

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -340,6 +340,7 @@ function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target'
         --preview=\"$preview\"
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
+        $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     echo $base
     echo $target

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -339,7 +339,7 @@ function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target'
     set opts "
         --preview=\"$preview\"
         $FORGIT_FZF_DEFAULT_OPTS
-        -m -0
+        -m -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     echo $base

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -12,6 +12,11 @@ function forgit::inside_work_tree
     git rev-parse --is-inside-work-tree >/dev/null;
 end
 
+function forgit::reverse_lines
+    # tac is not available on OSX, tail -r is not available on Linux, so we use either of them
+    tac 2> /dev/null || tail -r
+end
+
 set -g forgit_pager        "$FORGIT_PAGER"
 set -g forgit_show_pager   "$FORGIT_SHOW_PAGER"
 set -g forgit_diff_pager   "$FORGIT_DIFF_PAGER"
@@ -344,8 +349,8 @@ function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target'
     "
     echo $base
     echo $target
-    git cherry "$base" "$target" --abbrev -v |
-        env FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f2 |
+    git cherry "$base" "$target" --abbrev -v | forgit::reverse_lines |
+        env FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f2 | forgit::reverse_lines |
         xargs -I% git cherry-pick %
 end
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -159,8 +159,8 @@ forgit::cherry::pick() {
         -m -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
-    git cherry "$base" "$target" --abbrev -v | cut -d ' ' -f2- |
-        FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f1 |
+    git cherry "$base" "$target" --abbrev -v |
+        FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f2 |
         xargs -I% git cherry-pick %
 }
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -3,6 +3,8 @@
 forgit::warn() { printf "%b[Warn]%b %s\n" '\e[0;33m' '\e[0m' "$@" >&2; }
 forgit::info() { printf "%b[Info]%b %s\n" '\e[0;32m' '\e[0m' "$@" >&2; }
 forgit::inside_work_tree() { git rev-parse --is-inside-work-tree >/dev/null; }
+# tac is not available on OSX, tail -r is not available on Linux, so we use either of them
+forgit::reverse_lines() { (tac 2> /dev/null || tail -r) }
 
 # optional render emoji characters (https://github.com/wfxr/emoji-cli)
 hash emojify &>/dev/null && forgit_emojify='|emojify'
@@ -159,8 +161,8 @@ forgit::cherry::pick() {
         -m -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
-    git cherry "$base" "$target" --abbrev -v |
-        FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f2 |
+    git cherry "$base" "$target" --abbrev -v | forgit::reverse_lines |
+        FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f2 | forgit::reverse_lines |
         xargs -I% git cherry-pick %
 }
 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -157,6 +157,7 @@ forgit::cherry::pick() {
         $FORGIT_FZF_DEFAULT_OPTS
         --preview=\"$preview\"
         -m -0
+        $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     git cherry "$base" "$target" --abbrev -v | cut -d ' ' -f2- |
         FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f1 |

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -156,7 +156,7 @@ forgit::cherry::pick() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         --preview=\"$preview\"
-        -m -0
+        -m -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     git cherry "$base" "$target" --abbrev -v | cut -d ' ' -f2- |


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

This PR improves `gcp` (cherry-pick) with the following features:

1. **Add FORGIT_CHERRY_PICK_FZF_OPTS**
The `gcp` command was the only command which did not have a variable to set command-specific `fzf` options. Add the according variable to source code and documentation.

2. **Preserve commit order on cherry pick**
When using a `fzf` find string which maches multiple lines, the commits could appear in a wrong order. Add `--tiebreak=index` to ensure that the correct commit order is preserved.

3. **Preserve +/- information on cherry pick**
The output of `git cherry` which is used to build the `fzf` input list for `forgit::cherry::pick` usually prefixes every line with a '-' for commits that have an equivalent in the target branch, and a '+' for commits that do not.
Previously forgit removed this information from the list. However, for the actual cherry-picking process this information is relevant, so we should keep it.

4. **Reverse order on cherry pick**
`glo` displays the newest commits on top of the list, while `gcp` displays the newest commits at the bottom. Reverse the order of `gcp` so that it has the same order like `glo`.

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
