### PR TITLE
Fix cherry pick preview

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -340,7 +340,7 @@ function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target'
         echo "Please specify target branch"
         return 1
     end
-    set preview "echo {1} | xargs -I% git show --color=always % | $forgit_show_pager"
+    set preview "echo {2} | xargs -I% git show --color=always % | $forgit_show_pager"
     set opts "
         --preview=\"$preview\"
         $FORGIT_FZF_DEFAULT_OPTS

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -154,7 +154,7 @@ forgit::cherry::pick() {
     base=$(git branch --show-current)
     [[ -z $1 ]] && echo "Please specify target branch" && return 1
     target="$1"
-    preview="echo {1} | xargs -I% git show --color=always % | $forgit_show_pager"
+    preview="echo {2} | xargs -I% git show --color=always % | $forgit_show_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         --preview=\"$preview\"


### PR DESCRIPTION
The preview on cherry pick was accidentally broken since we included the
+/- information in the commit list. Fix this by using the correct string
index.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
