### PR TITLE
Improve forgit::diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,11 @@ FORGIT_LOG_FZF_OPTS='
 ```
 #### other options
 
-| Option              | Description    | Default                                      |
-|---------------------|----------------|----------------------------------------------|
-| `FORGIT_LOG_FORMAT` | git log format | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
+| Option                      | Description                              | Default                                       |
+|-----------------------------|------------------------------------------|-----------------------------------------------|
+| `FORGIT_LOG_FORMAT`         | git log format                           | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
+| `FORGIT_PREVIEW_CONTEXT`    | lines of diff context in preview mode    | 3                                             |
+| `FORGIT_FULLSCREEN_CONTEXT` | lines of diff context in fullscreen mode | 10                                            |
 
 ### 📦 Optional dependencies
 

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -29,11 +29,13 @@ set -g forgit_log_format   "$FORGIT_LOG_FORMAT"
 
 set -x FORGIT_INSTALL_DIR (dirname (dirname (status -f)))
 
-test -z "$forgit_pager";        and set -g forgit_pager        (git config core.pager || echo 'cat')
-test -z "$forgit_show_pager";   and set -g forgit_show_pager   (git config pager.show || echo "$forgit_pager")
-test -z "$forgit_diff_pager";   and set -g forgit_diff_pager   (git config pager.diff || echo "$forgit_pager")
-test -z "$forgit_ignore_pager"; and set -g forgit_ignore_pager (type -q bat >/dev/null 2>&1 && echo 'bat -l gitignore --color=always' || echo 'cat')
-test -z "$forgit_log_format";   and set -g forgit_log_format   "-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset"
+test -z "$forgit_pager";              and set -g forgit_pager        (git config core.pager || echo 'cat')
+test -z "$forgit_show_pager";         and set -g forgit_show_pager   (git config pager.show || echo "$forgit_pager")
+test -z "$forgit_diff_pager";         and set -g forgit_diff_pager   (git config pager.diff || echo "$forgit_pager")
+test -z "$forgit_ignore_pager";       and set -g forgit_ignore_pager (type -q bat >/dev/null 2>&1 && echo 'bat -l gitignore --color=always' || echo 'cat')
+test -z "$forgit_log_format";         and set -g forgit_log_format   "-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset"
+test -z "$forgit_fullscreen_context"; and set -g forgit_fullscreen_context "10"
+test -z "$forgit_preview_context";    and set -g forgit_preview_context "3"
 
 # optional render emoji characters (https://github.com/wfxr/emoji-cli)
 type -q emojify >/dev/null 2>&1 && set -g forgit_emojify '|emojify'
@@ -43,7 +45,8 @@ function forgit::log -d "git commit viewer"
     forgit::inside_work_tree || return 1
 
     set files (echo $argv | sed -nE 's/.* -- (.*)/\1/p')
-    set preview "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
+    set preview_cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always -U$forgit_preview_context % -- $files | $forgit_show_pager"
+    set enter_cmd "echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always -U$forgit_fullscreen_context % -- $files | $forgit_show_pager"
 
     if test -n "$FORGIT_COPY_CMD"
         set copy_cmd $FORGIT_COPY_CMD
@@ -54,9 +57,9 @@ function forgit::log -d "git commit viewer"
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
-        --bind=\"enter:execute($preview |env LESS='-r' less)\"
+        --bind=\"enter:execute($enter_cmd |env LESS='-r' less)\"
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]' |$copy_cmd)\"
-        --preview=\"$preview\"
+        --preview=\"$preview_cmd\"
         $FORGIT_LOG_FZF_OPTS
     "
 
@@ -102,9 +105,8 @@ function forgit::diff -d "git diff viewer" --argument-names arg1 arg2
         end
     end
 
-    set preview_cmd "forgit::extract_file {} | xargs -I% git diff --color=always $commits -- % | $forgit_diff_pager"
-    # Show additional context on enter compared to preview
-    set enter_cmd "forgit::extract_file {} | xargs -I% git diff --color=always -U10000 $commits -- % | $forgit_diff_pager"
+    set preview_cmd "forgit::extract_file {} | xargs -I% git diff --color=always -U$forgit_preview_context $commits -- % | $forgit_diff_pager"
+    set enter_cmd "forgit::extract_file {} | xargs -I% git diff --color=always -U$forgit_fullscreen_context $commits -- % | $forgit_diff_pager"
 
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -102,13 +102,16 @@ function forgit::diff -d "git diff viewer" --argument-names arg1 arg2
         end
     end
 
-    set preview "forgit::extract_file {} | xargs git diff --color=always $commits -- | $forgit_diff_pager"
-    
+    set preview_cmd "forgit::extract_file {} | xargs -I% git diff --color=always $commits -- % | $forgit_diff_pager"
+    # Show additional context on enter compared to preview
+    set enter_cmd "forgit::extract_file {} | xargs -I% git diff --color=always -U10000 $commits -- % | $forgit_diff_pager"
+
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
-        +m -0 --bind=\"enter:execute($preview |env LESS='-r' less)\"
-        --preview=\"$preview\"
+        +m -0 --bind=\"enter:execute($enter_cmd | env LESS='-r' less)\"
+        --preview=\"$preview_cmd\"
         $FORGIT_DIFF_FZF_OPTS
+        --prompt=\"$commits > \"
     "
 
     eval git diff --name-status $commits -- $files* | 

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -16,19 +16,22 @@ forgit_ignore_pager=${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -
 forgit_blame_pager=${FORGIT_BLAME_PAGER:-$(git config pager.blame || echo "$forgit_pager")}
 
 forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset}
+forgit_fullscreen_context=${FORGIT_FULLSCREEN_CONTEXT:-10}
+forgit_preview_context=${FORGIT_PREVIEW_CONTEXT:-3}
 
 # git commit viewer
 forgit::log() {
     forgit::inside_work_tree || return 1
-    local cmd opts graph files log_format
+    local opts graph files log_format preview_cmd enter_cmd
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
-    cmd="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always % -- $files | $forgit_show_pager"
+    preview_cmd="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always -U$forgit_preview_context % -- $files | $forgit_show_pager"
+    enter_cmd="echo {} |grep -Eo '[a-f0-9]+' |head -1 |xargs -I% git show --color=always -U$forgit_fullscreen_context % -- $files | $forgit_show_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
-        --bind=\"enter:execute($cmd | LESS='-r' less)\"
+        --bind=\"enter:execute($enter_cmd | LESS='-r' less)\"
         --bind=\"ctrl-y:execute-silent(echo {} |grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]' |${FORGIT_COPY_CMD:-pbcopy})\"
-        --preview=\"$cmd\"
+        --preview=\"$preview_cmd\"
         $FORGIT_LOG_FZF_OPTS
     "
     graph=--graph
@@ -41,7 +44,7 @@ forgit::log() {
 # git diff viewer
 forgit::diff() {
     forgit::inside_work_tree || return 1
-    local cmd files opts commits repo
+    local files opts commits repo get_files preview_cmd enter_cmd
     [[ $# -ne 0 ]] && {
         if git rev-parse "$1" -- &>/dev/null ; then
             if [[ $# -gt 1 ]] && git rev-parse "$2" -- &>/dev/null; then
@@ -55,9 +58,8 @@ forgit::diff() {
     }
     repo="$(git rev-parse --show-toplevel)"
     get_files="cd '$repo' && echo {} | sed 's/.*] *//' | sed 's/  ->  / /'"
-    preview_cmd="$get_files | xargs -I% git diff --color=always $commits -- % | $forgit_diff_pager"
-    # Show additional context on enter compared to preview
-    enter_cmd="$get_files | xargs -I% git diff --color=always -U10000 $commits -- % | $forgit_diff_pager"
+    preview_cmd="$get_files | xargs -I% git diff --color=always -U$forgit_preview_context $commits -- % | $forgit_diff_pager"
+    enter_cmd="$get_files | xargs -I% git diff --color=always -U$forgit_fullscreen_context $commits -- % | $forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($enter_cmd | LESS='-r' less)\"

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -54,12 +54,16 @@ forgit::diff() {
         fi
     }
     repo="$(git rev-parse --show-toplevel)"
-    cmd="cd '$repo' && echo {} |sed 's/.*] *//' | sed 's/  ->  / /' |xargs -I% git diff --color=always $commits -- % | $forgit_diff_pager"
+    get_files="cd '$repo' && echo {} | sed 's/.*] *//' | sed 's/  ->  / /'"
+    preview_cmd="$get_files | xargs -I% git diff --color=always $commits -- % | $forgit_diff_pager"
+    # Show additional context on enter compared to preview
+    enter_cmd="$get_files | xargs -I% git diff --color=always -U10000 $commits -- % | $forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +m -0 --bind=\"enter:execute($cmd |LESS='-r' less)\"
-        --preview=\"$cmd\"
+        +m -0 --bind=\"enter:execute($enter_cmd | LESS='-r' less)\"
+        --preview=\"$preview_cmd\"
         $FORGIT_DIFF_FZF_OPTS
+        --prompt=\"$commits > \"
     "
     eval "git diff --name-status $commits -- ${files[*]} | sed -E 's/^([[:alnum:]]+)[[:space:]]+(.*)$/[\1]\t\2/'" |
         sed 's/\t/  ->  /2' | expand -t 8 |


### PR DESCRIPTION
While we can see the compact diff in the preview window on `gd`, I find it useful to see the complete file when entering the diff. Set the diff context to 10000 for this purpose.

Before:
![grafik](https://user-images.githubusercontent.com/45259958/179527882-95f83ae9-041e-4ac7-a8a0-5b51c9ecd11f.png)

After:
![grafik](https://user-images.githubusercontent.com/45259958/179526908-d54538f0-b391-4c58-95b4-c7038857610d.png)

Furthermore, display the diff range in the fzf prompt to see what we're looking at. With the normal `git diff` this is part of the diff output anyway, but with `diff-so-fancy` it's not, so this should be useful.

Before:
![grafik](https://user-images.githubusercontent.com/45259958/179525925-b5beb4a5-1372-4184-a543-6589f97367b2.png)

After:
![grafik](https://user-images.githubusercontent.com/45259958/179526499-e1acdf34-0d05-4102-8224-3ba15e88632a.png)

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
