### PR TITLE
grb: rebase on parent of the selected commit

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -437,10 +437,16 @@ function forgit::rebase -d "git rebase"
         --preview=\"$preview\"
         $FORGIT_REBASE_FZF_OPTS
     "
-    set commit (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | eval "$forgit_extract_sha")
+    set target_commit (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | eval "$forgit_extract_sha")
 
-    if test $commit
-        git rebase -i "$commit"
+    if test $target_commit
+        # "$target_commit~" is invalid when the commit is the first commit, but we can use "--root" instead
+        set prev_commit "$target_commit~"
+        if test "(git rev-parse '$target_commit')" = "(git rev-list --max-parents=0 HEAD)"
+            set prev_commit "--root"
+        end
+
+        git rebase -i "$prev_commit"
     end
 end
 

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -21,6 +21,15 @@ function forgit::reverse_lines
     end
 end
 
+function forgit::previous_commit
+    # "SHA~" is invalid when the commit is the first commit, but we can use "--root" instead
+    if test (git rev-parse $argv) = (git rev-list --max-parents=0 HEAD)
+        echo "--root"
+    else
+        echo "$argv~"
+    end
+end
+
 # extract the first git sha occuring in the input and strip trailing newline
 set -g forgit_extract_sha  "grep -Eo '[a-f0-9]+' | head -1 | tr -d '[:space:]'"
 
@@ -399,11 +408,7 @@ function forgit::fixup -d "git fixup"
     set target_commit (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | eval "$forgit_extract_sha")
 
     if test -n "$target_commit" && git commit --fixup "$target_commit"
-        # "$target_commit~" is invalid when the commit is the first commit, but we can use "--root" instead
-        set prev_commit "$target_commit~"
-        if test "(git rev-parse '$target_commit')" = "(git rev-list --max-parents=0 HEAD)"
-            set prev_commit "--root"
-        end
+        set prev_commit (forgit::previous_commit $target_commit)
 
         GIT_SEQUENCE_EDITOR=: git rebase --autostash -i --autosquash "$prev_commit"
     end
@@ -440,11 +445,7 @@ function forgit::rebase -d "git rebase"
     set target_commit (eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | eval "$forgit_extract_sha")
 
     if test $target_commit
-        # "$target_commit~" is invalid when the commit is the first commit, but we can use "--root" instead
-        set prev_commit "$target_commit~"
-        if test "(git rev-parse '$target_commit')" = "(git rev-list --max-parents=0 HEAD)"
-            set prev_commit "--root"
-        end
+        set prev_commit (forgit::previous_commit $target_commit)
 
         git rebase -i "$prev_commit"
     end


### PR DESCRIPTION
The git rebase command needs to be passed the parent commit of the one
you want to edit. When selecting a commit interactively via fzf, it
makes sense to automatically pass the parent commit of the selected one.
Within fzf it's otherwise quite hard to find the parent commit by hand
if you have found your commit via an fzf search string.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
