### PR TITLE
Interactively select branch in gcp

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -49,6 +49,8 @@ test -z "$forgit_log_format";         and set -g forgit_log_format   "-%C(auto)%
 test -z "$forgit_fullscreen_context"; and set -g forgit_fullscreen_context "10"
 test -z "$forgit_preview_context";    and set -g forgit_preview_context "3"
 
+set -g forgit_log_preview_options "--graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+
 # optional render emoji characters (https://github.com/wfxr/emoji-cli)
 type -q emojify >/dev/null 2>&1 && set -g forgit_emojify '|emojify'
 
@@ -270,7 +272,7 @@ end
 function forgit::branch::delete -d "git checkout branch deleter"
     forgit::inside_work_tree || return 1
 
-    set preview "git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+    set preview "git log {1} $forgit_log_preview_options"
 
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS
@@ -303,7 +305,7 @@ function forgit::checkout::branch -d "git checkout branch selector" --argument-n
         return $checkout_status
     end
 
-    set preview "git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+    set preview "git log {1} $forgit_log_preview_options"
 
     set opts "
         $FORGIT_FZF_DEFAULT_OPTS

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -28,6 +28,7 @@ forgit_ignore_pager=${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -
 forgit_blame_pager=${FORGIT_BLAME_PAGER:-$(git config pager.blame || echo "$forgit_pager")}
 
 forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset}
+forgit_log_preview_options="--graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
 forgit_fullscreen_context=${FORGIT_FULLSCREEN_CONTEXT:-10}
 forgit_preview_context=${FORGIT_PREVIEW_CONTEXT:-3}
 
@@ -255,7 +256,7 @@ forgit::checkout::branch() {
     [[ $# -ne 0 ]] && { git checkout -b "$@"; return $?; }
     local cmd preview opts branch
     cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
-    preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+    preview="git log {1} $forgit_log_preview_options"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index --header-lines=1
@@ -284,7 +285,7 @@ forgit::checkout::tag() {
     [[ $# -ne 0 ]] && { git checkout "$@"; return $?; }
     local cmd opts preview
     cmd="git tag -l --sort=-v:refname"
-    preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+    preview="git log {1} $forgit_log_preview_options"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
@@ -318,7 +319,7 @@ forgit::checkout::commit() {
 forgit::branch::delete() {
     forgit::inside_work_tree || return 1
     local preview opts cmd branches
-    preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
+    preview="git log {1} $forgit_log_preview_options"
 
     opts="
         $FORGIT_FZF_DEFAULT_OPTS

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -169,7 +169,7 @@ forgit::clean() {
 }
 
 forgit::cherry::pick() {
-    local base target preview opts
+    local base target preview opts fzf_selection fzf_exitval
     base=$(git branch --show-current)
     [[ -z $1 ]] && echo "Please specify target branch" && return 1
     target="$1"
@@ -180,9 +180,44 @@ forgit::cherry::pick() {
         -m -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
-    git cherry "$base" "$target" --abbrev -v | forgit::reverse_lines |
-        FZF_DEFAULT_OPTS="$opts" fzf | cut -d' ' -f2 | forgit::reverse_lines |
-        xargs -I% git cherry-pick %
+    fzf_selection=$(git cherry "$base" "$target" --abbrev -v | forgit::reverse_lines |
+        FZF_DEFAULT_OPTS="$opts" fzf)
+    fzf_exitval=$?
+    [[ $fzf_exitval != 0 ]] && return $fzf_exitval
+
+    commits=()
+    while IFS="" read -r line
+    do
+        commits+=("$line")
+    done < <(echo "$fzf_selection" | forgit::reverse_lines | cut -d' ' -f2)
+
+    git cherry-pick "${commits[@]}"
+}
+
+forgit::cherry::pick::from::branch() {
+    forgit::inside_work_tree || return 1
+    [[ $# -ne 0 ]] && { git checkout -b "$@"; return $?; }
+    local cmd preview opts branch exitval
+    cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
+    preview="git log {1} $forgit_log_preview_options"
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        +s +m --tiebreak=index --header-lines=1
+        --preview=\"$preview\"
+        $FORGIT_CHERRY_PICK_FROM_BRANCH_FZF_OPTS
+        "
+    # loop until either the branch selector is closed or a commit to be cherry
+    # picked has been selected from within a branch
+    while true
+    do
+        branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')"
+        [[ -z "$branch" ]] && return 1
+
+        forgit::cherry::pick "$branch"
+
+        exitval=$?
+        [[ $exitval != 130 ]] && return $exitval
+    done
 }
 
 forgit::rebase() {
@@ -458,7 +493,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_checkout_tag:-gct}"='forgit::checkout::tag'
     alias "${forgit_clean:-gclean}"='forgit::clean'
     alias "${forgit_stash_show:-gss}"='forgit::stash::show'
-    alias "${forgit_cherry_pick:-gcp}"='forgit::cherry::pick'
+    alias "${forgit_cherry_pick:-gcp}"='forgit::cherry::pick::from::branch'
     alias "${forgit_rebase:-grb}"='forgit::rebase'
     alias "${forgit_fixup:-gfu}"='forgit::fixup'
     alias "${forgit_blame:-gbl}"='forgit::blame'


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

When we want to perform a cherry pick, we had to pass the target branch as an argument to `gcp`. Forgit, however, aims to make git selections interactive where possible. Hence it seems natural to select the target branch interactively as well.

This change implements a new function `forgit::cherry::pick::from::branch` which opens an interactive branch selector and then calls the existing `forgit::cherry::pick` on the selected branch. Since this seems a far more intuitive way of performing a cherry pick I re-assigned the `gcp` alias to the new function.

The original `forgit::cherry::pick` had to be modified slightly in order to get a useful return code from it. Functionality stayed the same, though.

Along with this change I added a new global variable `forgit_log_preview_options` to reduce code duplication.

@wfxr @cjappl If this works for you and you approve this change I might re-implement #219 in the same manner. That would make me happy. 😄

<!-- Please include a summary of the change(and the related issue if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
