### PR TITLE
Adding wraps to fish - adding way to gcb an existing branch

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -300,17 +300,11 @@ function forgit::branch::delete -d "git checkout branch deleter" --wraps "git br
 end
 
 
-# note we "wrap" delete, we just need a snazzy way to get the branch list here
-function forgit::checkout::branch -d "git checkout branch selector" --argument-names 'input_branch_name' --wraps "git branch --delete" 
+function forgit::checkout::branch -d "git checkout branch selector" --argument-names 'input_branch_name' --wraps "git branch"
     forgit::inside_work_tree || return 1
 
     if test -n "$input_branch_name"
-        if git branch --list | grep "$input_branch_name" > /dev/null
-            git switch "$input_branch_name"
-        else
-            git switch -c "$input_branch_name"
-        end
-
+        git checkout -b "$input_branch_name"
         set checkout_status $status
         git status --short
         return $checkout_status

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -145,7 +145,7 @@ function forgit::diff -d "git diff viewer" --argument-names arg1 arg2
 end
 
 # git add selector
-function forgit::add -d "git add selector"
+function forgit::add -d "git add selector" --wraps "git add"
     forgit::inside_work_tree || return 1
     # Add files if passed as arguments
     count $argv >/dev/null && git add "$argv" && git status --short && return
@@ -208,7 +208,7 @@ function forgit::reset::head -d "git reset HEAD (unstage) selector"
 end
 
 # git checkout-restore selector
-function forgit::checkout::file -d "git checkout-file selector" --argument-names 'file_name'
+function forgit::checkout::file -d "git checkout-file selector" --argument-names 'file_name' --wraps "git checkout --"
     forgit::inside_work_tree || return 1
 
     if test -n "$file_name"
@@ -239,7 +239,7 @@ function forgit::checkout::file -d "git checkout-file selector" --argument-names
     echo 'Nothing to restore.'
 end
 
-function forgit::checkout::commit -d "git checkout commit selector" --argument-names 'commit_id'
+function forgit::checkout::commit -d "git checkout commit selector" --argument-names 'commit_id' --wraps "git checkout"
     forgit::inside_work_tree || return 1
 
     if test -n "$commit_id"
@@ -275,7 +275,7 @@ function forgit::checkout::commit -d "git checkout commit selector" --argument-n
         FZF_DEFAULT_OPTS="$opts" fzf | eval "$forgit_extract_sha" | xargs -I% git checkout % --
 end
 
-function forgit::branch::delete -d "git checkout branch deleter"
+function forgit::branch::delete -d "git checkout branch deleter" --wraps "git branch --delete"
     forgit::inside_work_tree || return 1
 
     set preview "git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"
@@ -300,12 +300,17 @@ function forgit::branch::delete -d "git checkout branch deleter"
 end
 
 
-
-function forgit::checkout::branch -d "git checkout branch selector" --argument-names 'input_branch_name'
+# note we "wrap" delete, we just need a snazzy way to get the branch list here
+function forgit::checkout::branch -d "git checkout branch selector" --argument-names 'input_branch_name' --wraps "git branch --delete" 
     forgit::inside_work_tree || return 1
 
     if test -n "$input_branch_name"
-        git checkout -b "$input_branch_name"
+        if git branch --list | grep "$input_branch_name" > /dev/null
+            git switch "$input_branch_name"
+        else
+            git switch -c "$input_branch_name"
+        end
+
         set checkout_status $status
         git status --short
         return $checkout_status
@@ -366,7 +371,7 @@ function forgit::clean -d "git clean selector"
     echo 'Nothing to clean.'
 end
 
-function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target'
+function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target' --wraps "git cherry-pick"
     forgit::inside_work_tree || return 1
     set base (git branch --show-current)
     if test -z "$target"
@@ -503,7 +508,7 @@ function forgit::ignore -d "git ignore generator"
      forgit::ignore::get $args
 end
 
-function forgit::revert::commit --argument-names 'commit_hash'
+function forgit::revert::commit --argument-names 'commit_hash' --wraps "git revert --"
     if test -n "$commit_hash"
         git revert -- "$commit_hash"
         set revert_status $status


### PR DESCRIPTION

I added a bunch of "wraps" commands to our functions. This is basically a quick and easy way to get function completion for free. Users can now tab complete most commands that take an argument
