### PR TITLE
Add ability to checkout existing branch with gcb

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -258,7 +258,18 @@ forgit::checkout::file() {
 # git checkout-branch selector
 forgit::checkout::branch() {
     forgit::inside_work_tree || return 1
-    [[ $# -ne 0 ]] && { git checkout -b "$@"; return $?; }
+    # if called with arguments, check if branch exists, else create a new one
+    if [[ $# -ne 0 ]]; then
+        if git show-branch "$@" &>/dev/null; then
+            git switch "$@"
+        else
+            git switch -c "$@"
+        fi
+        checkout_status=$?
+        git status --short
+        return $checkout_status
+    fi
+
     local cmd preview opts branch
     cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
     preview="git log {1} --graph --pretty=format:'$forgit_log_format' --color=always --abbrev-commit --date=relative"


### PR DESCRIPTION
Port @cjappl 's changes of #232 / d4b4ce39087a2dfe4812d54de7a9865fb2ba9855 to zsh/bash.

`gcb` can now be called with an existing branch as an argument.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
