### PR TITLE
Do not return an error in log, diff and stash show

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -93,6 +93,11 @@ function forgit::log -d "git commit viewer"
 
     eval "git log $graph --color=always --format='$log_format' $argv $forgit_emojify" |
         env FZF_DEFAULT_OPTS="$opts" fzf 
+
+    set fzf_exit_code $status
+    # exit successfully on 130 (ctrl-c/esc)
+    [ $fzf_exit_code = 130 ] && return 0
+    return $fzf_exit_code
 end
 
 function forgit::extract_file --argument-names 'path'
@@ -144,6 +149,10 @@ function forgit::diff -d "git diff viewer" --argument-names arg1 arg2
      expand -t 8 |
      env FZF_DEFAULT_OPTS="$opts" fzf
 
+    set fzf_exit_code $status
+    # exit successfully on 130 (ctrl-c/esc)
+    [ $fzf_exit_code = 130 ] && return 0
+    return $fzf_exit_code
 end
 
 # git add selector
@@ -347,6 +356,11 @@ function forgit::stash::show -d "git stash viewer"
         $FORGIT_STASH_FZF_OPTS
     "
     git stash list | env FZF_DEFAULT_OPTS="$opts" fzf
+
+    set fzf_exit_code $status
+    # exit successfully on 130 (ctrl-c/esc)
+    [ $fzf_exit_code = 130 ] && return 0
+    return $fzf_exit_code
 end
 
 # git clean selector

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -53,6 +53,10 @@ forgit::log() {
     log_format=${FORGIT_GLO_FORMAT:-$forgit_log_format}
     eval "git log $graph --color=always --format='$log_format' $* $forgit_emojify" |
         FZF_DEFAULT_OPTS="$opts" fzf
+    fzf_exit_code=$?
+    # exit successfully on 130 (ctrl-c/esc)
+    [[ $fzf_exit_code == 130 ]] && return 0
+    return $fzf_exit_code
 }
 
 # git diff viewer
@@ -89,6 +93,10 @@ forgit::diff() {
     eval "git diff --name-status $commits -- ${files[*]} | sed -E 's/^([[:alnum:]]+)[[:space:]]+(.*)$/[\1]\t\2/'" |
         sed 's/\t/  ->  /2' | expand -t 8 |
         FZF_DEFAULT_OPTS="$opts" fzf
+    fzf_exit_code=$?
+    # exit successfully on 130 (ctrl-c/esc)
+    [[ $fzf_exit_code == 130 ]] && return 0
+    return $fzf_exit_code
 }
 
 # git add selector
@@ -157,6 +165,10 @@ forgit::stash::show() {
         $FORGIT_STASH_FZF_OPTS
     "
     git stash list | FZF_DEFAULT_OPTS="$opts" fzf
+    fzf_exit_code=$?
+    # exit successfully on 130 (ctrl-c/esc)
+    [[ $fzf_exit_code == 130 ]] && return 0
+    return $fzf_exit_code
 }
 
 # git clean selector


### PR DESCRIPTION
fzf has the following exit codes:
0      Normal exit
1      No match
2      Error
130    Interrupted with CTRL-C or ESC

The forgit functions "log", "diff" and "stash show" are designed to display information, not to perform any action. Hence the fzf exit codes 1 and 130 should not be interpreted as errors, they are normal exit behavior. Exclude these error values and return 0 in these cases.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
