### PR TITLE
Improve handling of arguments in forgit::add

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -102,8 +102,6 @@ forgit::diff() {
 # git add selector
 forgit::add() {
     forgit::inside_work_tree || return 1
-    # Add files if passed as arguments
-    [[ $# -ne 0 ]] && git add "$@" && git status -su && return
 
     local changed unmerged untracked files opts preview extract
     changed=$(git config --get-color color.status.changed red)
@@ -128,7 +126,7 @@ forgit::add() {
         --preview=\"$preview\"
         $FORGIT_ADD_FZF_OPTS
     "
-    files=$(git -c color.status=always -c status.relativePaths=true status -su |
+    files=$(git -c color.status=always -c status.relativePaths=true status -su "$@" |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf |


### PR DESCRIPTION
currently, passing arguments to `forgit::add` bypasses the interactive selector and are passed directly to `git add`. This isn't particularly useful. So pass the arguments to the `git status` call instead, so fzf can be used to interactively select from the list.

This is particularly useful when calling `git forgit add` against a subdirectory or a shell glob (e.g. `git forgit add *(om[1,5])`)

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
