### PR TITLE
Do not "set -e" in standalone forgit

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -10,8 +10,6 @@
 # This gives users the choice to set aliases inside of their git config instead
 # of their shell config if they prefer.
 
-set -e
-
 source "$FORGIT_INSTALL_DIR/forgit.plugin.zsh"
 
 cmd="$1"


### PR DESCRIPTION
Setting the error option in bash bypasses error handling in the forgit functions, because the script immediatley exits in case of an error. Remove the option to make error handling possible. Bash scripts automatically return the exit code of the last statement, so standalone forgit will still return useful error codes.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
