### PR TITLE
Automatic releases

### DIFF
--- a/.github/scripts/changelog.sh
+++ b/.github/scripts/changelog.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+url=$(git remote get-url origin | sed -r 's/(.*)\.git/\1/')
+
+previous_tag=$(git describe --tags --abbrev=0 HEAD~)
+
+echo "Changes since $previous_tag:"
+echo
+
+# Loop through all commits since previous tag
+for rev in $(git log $previous_tag..HEAD --format="%H" --reverse --no-merges)
+do
+    summary=$(git log $rev~..$rev --format="%s")
+    # Exclude commits starting with "Meta"
+    if [[ $summary != Meta* ]]
+    then
+        # Print markdown list of commit headlines
+        echo "* [$summary]($url/commit/$rev)"
+        # Append commit body indented (blank lines and signoff trailer removed)
+        git log $rev~..$rev --format="%b" | sed '/^\s*$/d' | sed '/^Signed-off-by:/d' | \
+        while read -r line
+        do
+            # Escape markdown formatting symbols _ * `
+            echo "  $line" | sed 's/_/\\_/g' | sed 's/`/\\`/g' | sed 's/\*/\\\*/g'
+        done
+    fi
+done

--- a/.github/scripts/tag.sh
+++ b/.github/scripts/tag.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+head_tag=$(git describe --exact-match 2>/dev/null | true)
+
+if [[ ${head_tag} =~ [\d{2}.\d{2}.\d+] ]]
+then
+    echo "Current master already has version tag ${head_tag}"
+else
+    git config --local user.email "github-actions@users.noreply.github.com"
+    git config --local user.name "github-actions"
+    version=$(date +'%y.%m.0')
+    git tag -a ${version} -m "Release ${version}"
+    git push origin ${version}
+    echo "Pushed new tag:"
+    echo "${{github.server_url}}/${{github.repository}}/tag/${version}"
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,13 @@ name: ci
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events, but only for the master branch
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create Package
+        run: tar -czf forgit-${{github.ref_name}}.tar.gz --exclude LICENSE --exclude README.md *
+
+      - name: Generate Changelog
+        run: .github/scripts/changelog.sh > CHANGELOG.md
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: CHANGELOG.md
+          files: forgit-${{github.ref_name}}.tar.gz

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,20 @@
+name: Tag
+
+on:
+  schedule:
+    # Run on every first day of the month
+    - cron: '0 0 1 * *'
+
+jobs:
+
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create Tag
+        run: .github/scripts/tag.sh


### PR DESCRIPTION
This PR adds a GitHub action for automatically creating a GitHub release for each tag (refs #233).

The action is executed on every tag and creates a GitHub release. The release contains a .tar.gz asset and a changelog consisting of all commit messages since the previous tag. Commits with a commit message starting with "Meta" are excluded from the changelog.

I tested this action on my forgit fork and you can see a generated changelog here:

https://github.com/carlfriedrich/forgit/releases

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
