### PR TITLE
Meta: GitHub tag action: add commit key

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,6 +15,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          # The COMMIT_KEY secret contains a private SSH key. The associated public key
+          # has been added as a deploy key in the GitHub project. See:
+          # https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys
+          # This is necessary to make commits done by github-actions able to trigger
+          # further github-actions. See: https://stackoverflow.com/q/60418323/3018229.
+          ssh-key: "${{secrets.COMMIT_KEY}}"
 
       - name: Create Tag
         run: .github/scripts/tag.sh


### PR DESCRIPTION
The COMMIT_KEY secret contains a private SSH key. The associated public key has been added as a deploy key in the GitHub project. See: https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys

This is necessary to make commits done by github-actions able to trigger further github-actions. See:
https://stackoverflow.com/q/60418323/3018229.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
