### PR TITLE
Fix forgit diff displaying renames on MacOS

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -123,8 +123,8 @@ _forgit_diff() {
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"$commits > \"
     "
-    eval "git diff --name-status $commits -- ${files[*]} | sed -E 's/^([[:alnum:]]+)[[:space:]]+(.*)$/[\1]\t\2/'" |
-        sed 's/\t/  ->  /2' | expand -t 8 |
+    eval "git diff --name-status $commits -- ${files[*]} | sed -E 's/^([[:alnum:]]+)[[:space:]]+(.*)$/[\1]	\2/'" |
+        sed 's/	/  ->  /2' | expand -t 8 |
         FZF_DEFAULT_OPTS="$opts" fzf
     fzf_exit_code=$?
     # exit successfully on 130 (ctrl-c/esc)


### PR DESCRIPTION
MacOS's sed variant obviously does not parse '\t' as a tabstop per default. Replacing it with a literal tabstop to make this work.

Fixes #245

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
