### PR TITLE
Feature: Added git stash push selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Install `forgit` in just one click.
 
 - **Interactive `git stash` viewer** (`gss`)
 
+- **Interactive `git stash push` selector** (`gsp`)
+
 - **Interactive `git clean` selector** (`gclean`)
 
 - **Interactive `git cherry-pick` selector** (`gcp`)
@@ -150,6 +152,7 @@ forgit_checkout_commit=gco
 forgit_revert_commit=grc
 forgit_clean=gclean
 forgit_stash_show=gss
+forgit_stash_push=gsp
 forgit_cherry_pick=gcp
 forgit_rebase=grb
 forgit_blame=gbl
@@ -233,6 +236,7 @@ Customizing fzf options for each command individually is also supported:
 | `gco`    | `FORGIT_CHECKOUT_COMMIT_FZF_OPTS` |
 | `grc`    | `FORGIT_REVERT_COMMIT_OPTS`       |
 | `gss`    | `FORGIT_STASH_FZF_OPTS`           |
+| `gsp`    | `FORGIT_STASH_PUSH_OPTS`          |
 | `gclean` | `FORGIT_CLEAN_FZF_OPTS`           |
 | `grb`    | `FORGIT_REBASE_FZF_OPTS`          |
 | `gbl`    | `FORGIT_BLAME_FZF_OPTS`           |

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -204,6 +204,30 @@ _forgit_stash_show() {
     return $fzf_exit_code
 }
 
+# git stash push selector
+_forgit_stash_push() {
+    _forgit_inside_work_tree || return 1
+    # Stash files if passed as arguments
+    [[ $# -ne 0 ]] && git stash push -u "$@" && return
+    local opts preview files
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        -m
+        $FORGIT_STASH_PUSH_OPTS
+    "
+    preview="
+        if (git ls-files {} --error-unmatch) &> /dev/null; then
+            git diff --color=always {} | $_forgit_diff_pager
+        else
+            git diff --color=always /dev/null {} | $_forgit_diff_pager
+        fi
+    "
+    # Show both modified and untracked files
+    files=$(git ls-files --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
+    [[ -z "$files" ]] && return 1
+    echo "${files[@]}" | tr '\n' '\0' | git stash push -u --pathspec-file-nul --pathspec-from-file -
+}
+
 # git clean selector
 _forgit_clean() {
     _forgit_inside_work_tree || return 1
@@ -542,6 +566,7 @@ valid_commands=(
     "reset_head"
     "revert_commit"
     "stash_show"
+    "stash_push"
 )
 
 cmd="$1"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -65,6 +65,7 @@ _forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Cre
 _forgit_log_preview_options="--graph --pretty=format:'$_forgit_log_format' --color=always --abbrev-commit --date=relative"
 _forgit_fullscreen_context=${FORGIT_FULLSCREEN_CONTEXT:-10}
 _forgit_preview_context=${FORGIT_PREVIEW_CONTEXT:-3}
+_forgit_is_file_tracked="(git ls-files {} --error-unmatch) &> /dev/null"
 
 # git commit viewer
 _forgit_log() {
@@ -216,7 +217,7 @@ _forgit_stash_push() {
         $FORGIT_STASH_PUSH_OPTS
     "
     preview="
-        if (git ls-files {} --error-unmatch) &> /dev/null; then
+        if $_forgit_is_file_tracked; then
             git diff --color=always {} | $_forgit_diff_pager
         else
             git diff --color=always /dev/null {} | $_forgit_diff_pager
@@ -488,7 +489,7 @@ _forgit_blame() {
     "
     flags=$(git rev-parse --flags "$@")
     preview="
-        if (git ls-files {} --error-unmatch) &>/dev/null; then
+        if $_forgit_is_file_tracked; then
             git blame {} --date=short $flags | $_forgit_blame_pager
         else
             echo File not tracked

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -208,6 +208,21 @@ _forgit_stash_show() {
 # git stash push selector
 _forgit_stash_push() {
     _forgit_inside_work_tree || return 1
+    local msg args
+    args=( "$@" )
+    while (( "$#" )); do
+        case "$1" in
+            # allow message as argument
+            -m|--message)
+            msg="$2"
+            shift 2
+            ;;
+            # ignore -u as it's used implicitly
+            -u|--include-untracked) shift ;;
+            # pass to git directly when encountering anything else
+            *) git stash push "${args[@]}" && return $?
+        esac
+    done
     local opts preview files
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -224,7 +239,7 @@ _forgit_stash_push() {
     # Show both modified and untracked files
     files=$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
     [[ -z "$files" ]] && return 1
-    echo "${files[@]}" | tr '\n' '\0' | git stash push ${1:+-m "$1"} -u --pathspec-file-nul --pathspec-from-file -
+    echo "${files[@]}" | tr '\n' '\0' | git stash push ${msg:+-m "$msg"} -u --pathspec-file-nul --pathspec-from-file -
 }
 
 # git clean selector

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -224,7 +224,7 @@ _forgit_stash_push() {
         fi
     "
     # Show both modified and untracked files
-    files=$(git ls-files --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
+    files=$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
     [[ -z "$files" ]] && return 1
     echo "${files[@]}" | tr '\n' '\0' | git stash push -u --pathspec-file-nul --pathspec-from-file -
 }

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -208,8 +208,6 @@ _forgit_stash_show() {
 # git stash push selector
 _forgit_stash_push() {
     _forgit_inside_work_tree || return 1
-    # Stash files if passed as arguments
-    [[ $# -ne 0 ]] && git stash push -u "$@" && return
     local opts preview files
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -226,7 +224,7 @@ _forgit_stash_push() {
     # Show both modified and untracked files
     files=$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
     [[ -z "$files" ]] && return 1
-    echo "${files[@]}" | tr '\n' '\0' | git stash push -u --pathspec-file-nul --pathspec-from-file -
+    echo "${files[@]}" | tr '\n' '\0' | git stash push ${1:+-m "$1"} -u --pathspec-file-nul --pathspec-from-file -
 }
 
 # git clean selector

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -42,6 +42,10 @@ function forgit::stash::show -d "git stash viewer"
     "$FORGIT" stash_show $argv
 end
 
+function forgit::stash::push -d "git stash push selector" ()
+    "$FORGIT" stash_push $argv
+end
+
 function forgit::clean -d "git clean selector"
     "$FORGIT" clean $argv
 end
@@ -171,6 +175,12 @@ if test -z "$FORGIT_NO_ALIASES"
         alias $forgit_stash_show 'forgit::stash::show'
     else
         alias gss 'forgit::stash::show'
+    end
+
+    if test -n "$forgit_stash_push"
+        alias $forgit_stash_push 'forgit::stash::push'
+    else
+        alias gsp 'forgit::stash::push'
     end
 
     if test -n "$forgit_cherry_pick"

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -55,6 +55,10 @@ forgit::stash::show() {
     "$FORGIT" stash_show "$@"
 }
 
+forgit::stash::push() {
+    "$FORGIT" stash_push "$@"
+}
+
 forgit::clean() {
     "$FORGIT" clean "$@"
 }
@@ -139,6 +143,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_checkout_tag:-gct}"='forgit::checkout::tag'
     alias "${forgit_clean:-gclean}"='forgit::clean'
     alias "${forgit_stash_show:-gss}"='forgit::stash::show'
+    alias "${forgit_stash_push:-gsp}"='forgit::stash::push'
     alias "${forgit_cherry_pick:-gcp}"='forgit::cherry::pick::from::branch'
     alias "${forgit_rebase:-grb}"='forgit::rebase'
     alias "${forgit_fixup:-gfu}"='forgit::fixup'


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Added an interactive git stash push selector, that works similar to `forgit::add`. The alias for it is `gsp`. I thought about passing arguments to the command to be able to use e.g. `-m "name"` to be able to name the stash entry, but had no luck implementing this so far. If anyone has an idea, let me know and I'll update my PR. From my perspective we could merge this PR without this additional feature. 

This closes #243 

https://user-images.githubusercontent.com/88739791/204108329-c8846a1b-3dbc-411a-be13-873e2d9bf39e.mp4

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [X] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
