### PR TITLE
Provide an input branch with gcp again

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -249,7 +249,7 @@ _forgit_cherry_pick_from_branch() {
     _forgit_inside_work_tree || return 1
     local cmd preview opts branch exitval input_branch args
     args=("$@")
-    if [[ $# -ne 0 ]] && [[ $(git rev-parse --verify ${args[0]} 2>/dev/null) ]]; then
+    if [[ $# -ne 0 ]] && [[ $(git rev-parse --verify "${args[0]}" 2>/dev/null) ]]; then
         input_branch=${args[0]}
     fi
     cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -249,7 +249,7 @@ _forgit_cherry_pick_from_branch() {
     _forgit_inside_work_tree || return 1
     local cmd preview opts branch exitval input_branch args
     args=("$@")
-    if [[ $# -ne 0 ]] && [[ $(git rev-parse --verify "${args[0]}" 2>/dev/null) ]]; then
+    if [[ $# -ne 0 ]]; then
         input_branch=${args[0]}
     fi
     cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
@@ -276,7 +276,7 @@ _forgit_cherry_pick_from_branch() {
         _forgit_cherry_pick "$branch"
 
         exitval=$?
-        [[ $exitval != 130 ]] && return $exitval
+        [[ $exitval != 130 ]] || [[ $# -ne 0 ]] && return $exitval
     done
 }
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -247,10 +247,10 @@ _forgit_cherry_pick() {
 
 _forgit_cherry_pick_from_branch() {
     _forgit_inside_work_tree || return 1
-    local cmd preview opts branch exitval input_branch
-
-    if [[ $# -ne 0 ]] && [[ `git rev-parse --verify $@ 2>/dev/null` ]]; then
-        input_branch=$@
+    local cmd preview opts branch exitval input_branch args
+    args=("$@")
+    if [[ $# -ne 0 ]] && [[ $(git rev-parse --verify ${args[0]} 2>/dev/null) ]]; then
+        input_branch=${args[0]}
     fi
     cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
     preview="git log {1} $_forgit_log_preview_options"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -247,8 +247,11 @@ _forgit_cherry_pick() {
 
 _forgit_cherry_pick_from_branch() {
     _forgit_inside_work_tree || return 1
-    [[ $# -ne 0 ]] && { git checkout -b "$@"; return $?; }
-    local cmd preview opts branch exitval
+    local cmd preview opts branch exitval input_branch
+
+    if [[ $# -ne 0 ]] && [[ `git rev-parse --verify $@ 2>/dev/null` ]]; then
+        input_branch=$@
+    fi
     cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
     preview="git log {1} $_forgit_log_preview_options"
     opts="
@@ -261,7 +264,13 @@ _forgit_cherry_pick_from_branch() {
     # picked has been selected from within a branch
     while true
     do
-        branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')"
+        if [[ -z $input_branch ]]; then
+            branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')"
+        else
+            branch=$input_branch
+        fi
+
+        unset input_branch
         [[ -z "$branch" ]] && return 1
 
         _forgit_cherry_pick "$branch"


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

Noticed there was a change recently that broke the ability to pass in an input branch to `gcp`.

This change is the following:

- Fix faulty logic that just led to a `git checkout -b` being called when you pass in an argument to `gcp`
- If an argument was passed in, check if it is a valid branch, if so, set the `input_branch` var
- If `input_branch` is set, use it to do the cherry pick, as opposed to the first FZF selection.


PLEASE HELP ME REVIEW THIS, @carlfriedrich and @wfxr. I am such a bash syntax newbie, I don't know if I'm writing bad code 😄 



<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
