### PR TITLE
feat: allow overriding default $SHELL /bin/bash

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -12,8 +12,10 @@
 # This gives users the choice to set aliases inside of their git config instead
 # of their shell config if they prefer.
 
-# Set shell for fzf preview commands
-SHELL=/bin/bash
+# shellcheck suggests "command -v xxx" instead. But it's not a replacement to
+# `which`. See https://github.com/koalaman/shellcheck/issues/1162
+# shellcheck disable=2230
+SHELL="$(which bash)" # Set shell for fzf preview commands
 
 # Get absolute forgit path
 FORGIT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/$(basename -- "${BASH_SOURCE[0]}")

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -12,8 +12,9 @@
 # This gives users the choice to set aliases inside of their git config instead
 # of their shell config if they prefer.
 
-# shellcheck suggests "command -v xxx" instead. But it's not a replacement to
-# `which`. See https://github.com/koalaman/shellcheck/issues/1162
+# Disable shellcheck for "which", because it suggests "command -v xxx" instead,
+# which is not a working replacement.
+# See https://github.com/koalaman/shellcheck/issues/1162
 # shellcheck disable=2230
 SHELL="$(which bash)" # Set shell for fzf preview commands
 


### PR DESCRIPTION
Some systems do not have /bin/bash. e.g., Alpine and NixOS. This change allows the user to provide one's own path of bash to fzf. It solves the error `fork/exec /bin/bash`.

Note that `fzf --preview 'xxxx'` essentially executes `$SHELL -c 'xxxx'`, so I tested on bash, zsh, and fish forgit::blame and it worked.
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
