### PR TITLE
Ensure that `grc` and `gcp` always have the correct ordering, regardless of how they were input

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -221,9 +221,13 @@ _forgit_clean() {
 
 _forgit_cherry_pick() {
     local base target preview opts fzf_selection fzf_exitval
+
     base=$(git branch --show-current)
+    [[ -z "$base" ]] && echo "Current commit is not on a branch." && return 1
+
     [[ -z $1 ]] && echo "Please specify target branch" && return 1
     target="$1"
+
     preview="echo {} | cut -f2- | $_forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -232,7 +236,7 @@ _forgit_cherry_pick() {
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     fzf_selection=$(git cherry "$base" "$target" --abbrev -v | nl | _forgit_reverse_lines |
-        FZF_DEFAULT_OPTS="$opts" fzf | sort -nk1 | cut -f2-)
+        FZF_DEFAULT_OPTS="$opts" fzf | sort --numeric-sort --key=1 --reverse | cut -f2-)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
     [[ -z "$fzf_selection" ]] && return $fzf_exitval

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -228,6 +228,11 @@ _forgit_cherry_pick() {
     [[ -z $1 ]] && echo "Please specify target branch" && return 1
     target="$1"
 
+    # in this function, we do something interesting to maintain proper ordering as it's assumed 
+    # you generally want to cherry pick newest->oldest when you multiselect
+    # The instances of "cut", "nl" and "sort" all serve this purpose
+    # Please see https://github.com/wfxr/forgit/issues/253 for more details
+
     preview="echo {} | cut -f2- | $_forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
@@ -460,6 +465,11 @@ _forgit_revert_commit() {
         $FORGIT_REVERT_COMMIT_OPTS
     "
 
+    # in this function, we do something interesting to maintain proper ordering as it's assumed 
+    # you generally want to revert oldest->newest when you multiselect
+    # The instances of "cut", "nl" and "sort" all serve this purpose
+    # Please see https://github.com/wfxr/forgit/issues/253 for more details
+
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
     preview="echo {} | cut -f2- | $_forgit_extract_sha | xargs -I% git show --color=always % -- $files | $_forgit_show_pager"
 
@@ -467,7 +477,8 @@ _forgit_revert_commit() {
     IFS=$'\n' commits=($(eval "$cmd" | 
         nl |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" -m | 
-        sort --numeric-sort --key=1 | cut -f2- |
+        sort --numeric-sort --key=1 | 
+        cut -f2- |
         sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/'))
 
     [ ${#commits[@]} -eq 0 ] && return 1

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -235,6 +235,7 @@ _forgit_cherry_pick() {
         FZF_DEFAULT_OPTS="$opts" fzf | sort -nk1 | cut -f2-)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
+    [[ -z "$fzf_selection" ]] && return $fzf_exitval
 
     commits=()
     while IFS="" read -r line

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -224,15 +224,15 @@ _forgit_cherry_pick() {
     base=$(git branch --show-current)
     [[ -z $1 ]] && echo "Please specify target branch" && return 1
     target="$1"
-    preview="echo {} | $_forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager"
+    preview="echo {} | cut -f2- | $_forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         --preview=\"$preview\"
-        -m -0 --tiebreak=index
+        --multi --ansi --with-nth 2.. -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
-    fzf_selection=$(git cherry "$base" "$target" --abbrev -v | _forgit_reverse_lines |
-        FZF_DEFAULT_OPTS="$opts" fzf)
+    fzf_selection=$(git cherry "$base" "$target" --abbrev -v | nl | _forgit_reverse_lines |
+        FZF_DEFAULT_OPTS="$opts" fzf | sort -nk1 | cut -f2-)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -229,7 +229,7 @@ _forgit_cherry_pick() {
     target="$1"
 
     # in this function, we do something interesting to maintain proper ordering as it's assumed 
-    # you generally want to cherry pick newest->oldest when you multiselect
+    # you generally want to cherry pick oldest->newest when you multiselect
     # The instances of "cut", "nl" and "sort" all serve this purpose
     # Please see https://github.com/wfxr/forgit/issues/253 for more details
 
@@ -466,7 +466,7 @@ _forgit_revert_commit() {
     "
 
     # in this function, we do something interesting to maintain proper ordering as it's assumed 
-    # you generally want to revert oldest->newest when you multiselect
+    # you generally want to revert newest->oldest when you multiselect
     # The instances of "cut", "nl" and "sort" all serve this purpose
     # Please see https://github.com/wfxr/forgit/issues/253 for more details
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -247,6 +247,8 @@ _forgit_cherry_pick() {
         commits+=("$line")
     done < <(echo "$fzf_selection" | _forgit_reverse_lines | cut -d' ' -f2)
 
+    [ ${#commits[@]} -eq 0 ] && return 1
+
     git cherry-pick "${commits[@]}"
 }
 
@@ -448,23 +450,29 @@ _forgit_branch_delete() {
 _forgit_revert_commit() {
     _forgit_inside_work_tree || return 1
     [[ $# -ne 0 ]] && { git revert "$@"; return $?; }
+
     local cmd opts files preview commits IFS
     cmd="git log --graph --color=always --format='$_forgit_log_format' $* $_forgit_emojify"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s --tiebreak=index
+        --ansi --with-nth 2..
         $FORGIT_REVERT_COMMIT_OPTS
     "
+
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
-    preview="echo {} | $_forgit_extract_sha | xargs -I% git show --color=always % -- $files | $_forgit_show_pager"
+    preview="echo {} | cut -f2- | $_forgit_extract_sha | xargs -I% git show --color=always % -- $files | $_forgit_show_pager"
+
     # shellcheck disable=2207
-    IFS=$'\n' commits=($(eval "$cmd" |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" -m |
+    IFS=$'\n' commits=($(eval "$cmd" | 
+        nl |
+        FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" -m | 
+        sort --numeric-sort --key=1 | cut -f2- |
         sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/'))
+
     [ ${#commits[@]} -eq 0 ] && return 1
-    for commit in "${commits[@]}"; do
-        git revert "$commit"
-    done
+
+    git revert "${commits[@]}"
 }
 
 # git blame viewer


### PR DESCRIPTION


## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

Closes #253. Essentially the idea is this: 

- When cherry picking a group of commits, most of the time you want to cherry pick oldest to newest. This means you have the lowest chance of having a conflict or error
- when reverting a commit. You most often want to revert from newest to oldest. Similarly prevents errors

This commit does that, based on the wonderful suggestion on how to do that from @carlfriedrich in the linked ticket (#253). 

Best reviewed with turning whitespace off, as I added some in there. I also made a few small stylistic changes so these two functions mirrored each other more closely, as fundamentally they do similar things (get a list of commits, and feed them to the function).


TO TEST:

- Try to revert one commit
- Try to revert 3 commits in all orders  - the resulting order should be the same, from newest to oldest
- Try to cherry pick one commit
- Try to cherry pick 3 commits in all orders -   the resulting order should always be the same, from oldest to newest

I was also adding a line to confirm this, which may be helpful in your testing:
```
echo "${commits[@]}"
```

on lines 251 and 247.


## Type of change

- [x] Bug fix
- [x] New feature

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Mac OS X

