### PR TITLE
Adding the ability to grh from a subdirectory

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -187,7 +187,7 @@ _forgit_reset_head() {
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
     files="$(git diff --staged --name-only | FZF_DEFAULT_OPTS="$opts" fzf)"
-    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD $rootdir/% && git status --short && return
+    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD "$rootdir"/% && git status --short && return
     echo 'Nothing to unstage.'
 }
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -177,16 +177,17 @@ _forgit_add() {
 # git reset HEAD (unstage) selector
 _forgit_reset_head() {
     _forgit_inside_work_tree || return 1
-    local cmd files opts
-    cmd="git diff --cached --color=always -- {} | $_forgit_diff_pager "
+    local cmd files opts rootdir
+    rootdir=$(git rev-parse --show-toplevel)
+    cmd="git diff --staged --color=always -- $rootdir/{} | $_forgit_diff_pager "
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
         --preview=\"$cmd\"
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    files="$(git diff --cached --name-only --relative | FZF_DEFAULT_OPTS="$opts" fzf)"
-    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD % && git status --short && return
+    files="$(git diff --staged --name-only | FZF_DEFAULT_OPTS="$opts" fzf)"
+    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git reset -q HEAD $rootdir/% && git status --short && return
     echo 'Nothing to unstage.'
 }
 


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code

## Description

Closes #254 

`grh` didn't work if you were in a subdirectory. From the issue ticket:

"
 Steps to repro

    Change a file
    git add the file
    mkdir somesubdirectory && cd somesubdirectory
    grh

Expected:

    File show up in forgit, if you tab select them they get unstaged

Observed:
Nothing to unstage.
"

This should fix that.

## Type of change

- [x] Bug fix

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Mac OS X

