### PR TITLE
Only show available cherry picks

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -282,7 +282,7 @@ _forgit_cherry_pick() {
         --multi --ansi --with-nth 2.. -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
-    fzf_selection=$(git log --right-only --color=always --cherry-pick --oneline $base...$target | nl |
+    fzf_selection=$(git log --right-only --color=always --cherry-pick --oneline "$base"..."$target" | nl |
         FZF_DEFAULT_OPTS="$opts" fzf | sort --numeric-sort --key=1 | cut -f 2- | cut -c 1-8)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -282,7 +282,7 @@ _forgit_cherry_pick() {
         --multi --ansi --with-nth 2.. -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
-    fzf_selection=$(git cherry "$base" "$target" --abbrev -v | nl | _forgit_reverse_lines |
+    fzf_selection=$(git log --color=always --right-only --graph --cherry-pick --oneline $base...$target | nl |
         FZF_DEFAULT_OPTS="$opts" fzf | sort --numeric-sort --key=1 --reverse | cut -f2-)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -282,8 +282,8 @@ _forgit_cherry_pick() {
         --multi --ansi --with-nth 2.. -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
-    fzf_selection=$(git log --color=always --right-only --graph --cherry-pick --oneline $base...$target | nl |
-        FZF_DEFAULT_OPTS="$opts" fzf | sort --numeric-sort --key=1 --reverse | cut -f2-)
+    fzf_selection=$(git log --right-only --color=always --cherry-pick --oneline $base...$target | nl |
+        FZF_DEFAULT_OPTS="$opts" fzf | sort --numeric-sort --key=1 | cut -f 2- | cut -c 1-8)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
     [[ -z "$fzf_selection" ]] && return $fzf_exitval


### PR DESCRIPTION

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description
Fixes #264 

Only shows changes that are eligible for cherry-pick to the branch, not every commit. Also adds nice color to the output


Steps to test:
- Get two branches that have diverged (`thisBranch` and `otherBranch`
- `gcb thisBranch`
- `gcp otherBranch`

Expected:
- Only the commits in "otherBranch" that DO NOT appear in "thisBranch" appear in the fzf window
- If you cherry pick one of those commits, then `gcp otherBranch` again, it disappears from the fzf output (as it is successfully cherry-picked and not eligble for cherry-pick again.


## Type of change

- [x] New feature
- [x] Refactor

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
