### PR TITLE
Fixed: Untracked files with spaces in the path do not show a preview with ga

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -154,10 +154,10 @@ _forgit_add() {
         sed -e 's/^\\\"//' -e 's/\\\"\$//'"
     preview="
         file=\$(echo {} | $extract)
-        if (git status -s -- \$file | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
-            git diff --color=always --no-index -- /dev/null \$file | $_forgit_diff_pager | sed '2 s/added:/untracked:/'
+        if (git status -s -- \\\"\$file\\\" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
+            git diff --color=always --no-index -- /dev/null \\\"\$file\\\" | $_forgit_diff_pager | sed '2 s/added:/untracked:/'
         else
-            git diff --color=always -- \$file | $_forgit_diff_pager
+            git diff --color=always -- \\\"\$file\\\" | $_forgit_diff_pager
         fi"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Added escaped quotes around the file variable inside the preview string in `_forgit_add()` to prevent word splitting on files that have spaces in their file path. As a result such files do now generate a preview as expected.

Closes #263

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
