### PR TITLE
Fish: Allow git-forgit in vendor_conf.d

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -2,6 +2,9 @@
 
 set INSTALL_DIR (dirname (dirname (status -f)))
 set FORGIT "$INSTALL_DIR/conf.d/bin/git-forgit"
+if [ ! -e "$FORGIT" ]
+    set FORGIT "$INSTALL_DIR/vendor_conf.d/bin/git-forgit"
+end
 
 function forgit::warn
     printf "%b[Warn]%b %s\n" '\e[0;33m' '\e[0m' "$argv" >&2;


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

In the fish wrapper, assume forgit-git to be in vendor_conf.d/bin in case it can not be found in conf.d/bin. This fixes forgit not working with fish when located in /usr/share/fish/vendor_conf.d, as is the case with the [forgit](https://aur.archlinux.org/packages/forgit) and [forgit-git](https://aur.archlinux.org/packages/forgit-git) AUR packages. The location at conf.d is kept (and stays the default), so forgit does not break compatibility with fish plugin managers, such as fisher.

Closes #270

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
