### PR TITLE
Add alias gbl for forgit::blame in fish

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -167,7 +167,6 @@ if test -z "$FORGIT_NO_ALIASES"
         alias gbd 'forgit::branch::delete'
     end
 
-
     if test -n "$forgit_clean"
         alias $forgit_clean 'forgit::clean'
     else
@@ -214,6 +213,12 @@ if test -z "$FORGIT_NO_ALIASES"
         alias $forgit_revert_commit 'forgit::revert::commit'
     else
         alias grc 'forgit::revert::commit'
+    end
+
+    if test -n "$forgit_blame"
+        alias $forgit_blame 'forgit::blame'
+    else
+        alias gbl 'forgit::blame'
     end
 
 end


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Added the alias `gbl` for `forgit::blame` to the fish wrapper, so the behavior in fish is the same as in bash/zsh.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
