### PR TITLE
Add bash completions for forgit functions and aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,10 @@ export FORGIT_LOG_FZF_OPTS='
 - `gd` supports specifying revision(eg, `gd HEAD~`, `gd v1.0 README.md`).
 - Call `gi` with arguments to get the wanted `.gitignore` contents directly(eg, `gi cmake c++`).
 - You can use the commands as sub-commands of `git`, see [#147](https://github.com/wfxr/forgit/issues/147) for details.
-- Put [completions/git-forgit.bash](https://github.com/wfxr/forgit/blob/master/completions/git-forgit.bash) in
+- Put [`completions/git-forgit.bash`](https://github.com/wfxr/forgit/blob/master/completions/git-forgit.bash) in
   `~/.local/share/bash-completion/completions` to have bash tab completion for `git forgit` and configured git aliases.
+- Source [`completions/git-forgit.bash`](https://github.com/wfxr/forgit/blob/master/completions/git-forgit.bash) explicitly to have
+  bash tab completion for forgit shell functions and aliases (e.g. `gcb <tab>` completes branches).
 
 ### 📃 License
 

--- a/completions/git-forgit.bash
+++ b/completions/git-forgit.bash
@@ -6,6 +6,9 @@
 #
 #   /usr/share/bash-completion/completions
 #   ~/.local/share/bash-completion/completions
+#
+# When using forgit via the shell plugin, source this file explicitly after
+# forgit.plugin.zsh to enable tab completion for shell functions and aliases.
 
 _git_branch_delete()
 {
@@ -104,3 +107,49 @@ _git_forgit()
 			;;
 	esac
 }
+
+# Check if forgit plugin is loaded
+if [[ $(type -t forgit::add) == function ]]
+then
+	# We're reusing existing git completion functions, so load those first
+	# and check if completion function exists afterwards.
+	_completion_loader git
+	[[ $(type -t __git_complete) == function ]] || return 1
+
+	# Completion for forgit plugin shell functions
+	__git_complete forgit::add _git_add
+	__git_complete forgit::branch::delete _git_branch_delete
+	__git_complete forgit::checkout::branch _git_checkout_branch
+	__git_complete forgit::checkout::commit _git_checkout
+	__git_complete forgit::checkout::file _git_checkout_file
+	__git_complete forgit::checkout::tag _git_checkout_tag
+	__git_complete forgit::cherry::pick _git_cherry_pick
+	__git_complete forgit::cherry::pick::from::branch _git_checkout_branch
+	__git_complete forgit::clean _git_clean
+	__git_complete forgit::diff _git_diff
+	__git_complete forgit::fixup _git_branch
+	__git_complete forgit::log _git_log
+	__git_complete forgit::rebase _git_rebase
+	__git_complete forgit::reset::head _git_reset
+	__git_complete forgit::revert::commit _git_revert
+	__git_complete forgit::stash::show _git_stash_show
+
+	# Completion for forgit plugin shell aliases
+	if [[ -z "$FORGIT_NO_ALIASES" ]]; then
+		__git_complete "${forgit_add}" _git_add
+		__git_complete "${forgit_branch_delete}" _git_branch_delete
+		__git_complete "${forgit_checkout_branch}" _git_checkout_branch
+		__git_complete "${forgit_checkout_commit}" _git_checkout
+		__git_complete "${forgit_checkout_file}" _git_checkout_file
+		__git_complete "${forgit_checkout_tag}" _git_checkout_tag
+		__git_complete "${forgit_cherry_pick}" _git_checkout_branch
+		__git_complete "${forgit_clean}" _git_clean
+		__git_complete "${forgit_diff}" _git_diff
+		__git_complete "${forgit_fixup}" _git_branch
+		__git_complete "${forgit_log}" _git_log
+		__git_complete "${forgit_rebase}" _git_rebase
+		__git_complete "${forgit_reset_head}" _git_reset
+		__git_complete "${forgit_revert_commit}" _git_revert
+		__git_complete "${forgit_stash_show}" _git_stash_show
+	fi
+fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -133,22 +133,43 @@ forgit::ignore::clean() {
 # register aliases
 # shellcheck disable=SC2139
 if [[ -z "$FORGIT_NO_ALIASES" ]]; then
-    alias "${forgit_add:-ga}"='forgit::add'
-    alias "${forgit_reset_head:-grh}"='forgit::reset::head'
-    alias "${forgit_log:-glo}"='forgit::log'
-    alias "${forgit_diff:-gd}"='forgit::diff'
-    alias "${forgit_ignore:-gi}"='forgit::ignore'
-    alias "${forgit_checkout_file:-gcf}"='forgit::checkout::file'
-    alias "${forgit_checkout_branch:-gcb}"='forgit::checkout::branch'
-    alias "${forgit_checkout_commit:-gco}"='forgit::checkout::commit'
-    alias "${forgit_branch_delete:-gbd}"='forgit::branch::delete'
-    alias "${forgit_revert_commit:-grc}"='forgit::revert::commit'
-    alias "${forgit_checkout_tag:-gct}"='forgit::checkout::tag'
-    alias "${forgit_clean:-gclean}"='forgit::clean'
-    alias "${forgit_stash_show:-gss}"='forgit::stash::show'
-    alias "${forgit_stash_push:-gsp}"='forgit::stash::push'
-    alias "${forgit_cherry_pick:-gcp}"='forgit::cherry::pick::from::branch'
-    alias "${forgit_rebase:-grb}"='forgit::rebase'
-    alias "${forgit_fixup:-gfu}"='forgit::fixup'
-    alias "${forgit_blame:-gbl}"='forgit::blame'
+
+    export forgit_add="${forgit_add:-ga}"
+    export forgit_reset_head="${forgit_reset_head:-grh}"
+    export forgit_log="${forgit_log:-glo}"
+    export forgit_diff="${forgit_diff:-gd}"
+    export forgit_ignore="${forgit_ignore:-gi}"
+    export forgit_checkout_file="${forgit_checkout_file:-gcf}"
+    export forgit_checkout_branch="${forgit_checkout_branch:-gcb}"
+    export forgit_checkout_commit="${forgit_checkout_commit:-gco}"
+    export forgit_checkout_tag="${forgit_checkout_tag:-gct}"
+    export forgit_branch_delete="${forgit_branch_delete:-gbd}"
+    export forgit_revert_commit="${forgit_revert_commit:-grc}"
+    export forgit_clean="${forgit_clean:-gclean}"
+    export forgit_stash_show="${forgit_stash_show:-gss}"
+    export forgit_stash_push="${forgit_stash_push:-gsp}"
+    export forgit_cherry_pick="${forgit_cherry_pick:-gcp}"
+    export forgit_rebase="${forgit_rebase:-grb}"
+    export forgit_fixup="${forgit_fixup:-gfu}"
+    export forgit_blame="${forgit_blame:-gbl}"
+
+    alias "${forgit_add}"='forgit::add'
+    alias "${forgit_reset_head}"='forgit::reset::head'
+    alias "${forgit_log}"='forgit::log'
+    alias "${forgit_diff}"='forgit::diff'
+    alias "${forgit_ignore}"='forgit::ignore'
+    alias "${forgit_checkout_file}"='forgit::checkout::file'
+    alias "${forgit_checkout_branch}"='forgit::checkout::branch'
+    alias "${forgit_checkout_commit}"='forgit::checkout::commit'
+    alias "${forgit_checkout_tag}"='forgit::checkout::tag'
+    alias "${forgit_branch_delete}"='forgit::branch::delete'
+    alias "${forgit_revert_commit}"='forgit::revert::commit'
+    alias "${forgit_clean}"='forgit::clean'
+    alias "${forgit_stash_show}"='forgit::stash::show'
+    alias "${forgit_stash_push}"='forgit::stash::push'
+    alias "${forgit_cherry_pick}"='forgit::cherry::pick::from::branch'
+    alias "${forgit_rebase}"='forgit::rebase'
+    alias "${forgit_fixup}"='forgit::fixup'
+    alias "${forgit_blame}"='forgit::blame'
+
 fi


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

This is a follow-up to #235 and adds bash completion to the plugin functions and aliases.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
