### PR TITLE
Allow specifying custom blame date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ export FORGIT_LOG_FZF_OPTS='
 | `FORGIT_LOG_FORMAT`         | git log format                           | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
 | `FORGIT_PREVIEW_CONTEXT`    | lines of diff context in preview mode    | 3                                             |
 | `FORGIT_FULLSCREEN_CONTEXT` | lines of diff context in fullscreen mode | 10                                            |
+| `FORGIT_BLAME_DATE`         | git blame date format                    | short                                         |
 
 ### 📦 Optional dependencies
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -540,7 +540,7 @@ _forgit_blame() {
     flags=$(git rev-parse --flags "$@")
     preview="
         if $_forgit_is_file_tracked; then
-            git blame {} --date=short $flags | $_forgit_blame_pager
+            git blame {} --date=${FORGIT_BLAME_DATE:-short} $flags | $_forgit_blame_pager
         else
             echo File not tracked
         fi


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Allow the user to set a custom date format for `gbl` in `FORGIT_BLAME_DATE` for the preview. The current value (short) stays the default, so the preview does not get cluttered. This is especially useful with delta, which currently fails to apply it's blame theme when date is set to anything other than iso8601 or iso8601-local, see https://github.com/wfxr/forgit/issues/268#issuecomment-1377916562

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
