### PR TITLE
Add alias gct for forgit::checkout::tag in fish

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -221,4 +221,10 @@ if test -z "$FORGIT_NO_ALIASES"
         alias gbl 'forgit::blame'
     end
 
+    if test -n "$forgit_checkout_tag"
+        alias $forgit_checkout_tag 'forgit::checkout::tag'
+    else
+        alias gct 'forgit::checkout::tag'
+    end
+
 end


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Noticed there was another alias missing for fish. This is the last one :)

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
