### PR TITLE
Fix empty diff preview on renames

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -114,7 +114,7 @@ _forgit_diff() {
     repo="$(git rev-parse --show-toplevel)"
     # Store file names into an array so that they can be passed separately to 'git diff' later.
     # This is necessary for properly supporting renames as well as whitespaces in file names.
-    get_files="while read f; do files+=(\$f); done < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/')"
+    get_files="while IFS="$'\n'" read f; do files+=(\$f); done < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/')"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -12,11 +12,13 @@
 # This gives users the choice to set aliases inside of their git config instead
 # of their shell config if they prefer.
 
+# Set shell for fzf preview commands
 # Disable shellcheck for "which", because it suggests "command -v xxx" instead,
 # which is not a working replacement.
 # See https://github.com/koalaman/shellcheck/issues/1162
 # shellcheck disable=2230
-SHELL="$(which bash)" # Set shell for fzf preview commands
+SHELL="$(which bash)"
+export SHELL
 
 # Get absolute forgit path
 FORGIT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/$(basename -- "${BASH_SOURCE[0]}")

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -116,7 +116,7 @@ _forgit_diff() {
     repo="$(git rev-parse --show-toplevel)"
     # Store file names into an array so that they can be passed separately to 'git diff' later.
     # This is necessary for properly supporting renames as well as whitespaces in file names.
-    get_files="while IFS="$'\n'" read f; do files+=(\$f); done < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/')"
+    get_files="while IFS= read -r -d '' f; do files+=(\\\"\$f\\\"); done < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\x0/' | sed 's/$/\\\x0/')"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -112,14 +112,17 @@ _forgit_diff() {
         fi
     }
     repo="$(git rev-parse --show-toplevel)"
-    get_files="cd '$repo' && echo {} | sed 's/.*] *//' | sed 's/  ->  / /'"
+    # Store file names into an array so that they can be passed separately to 'git diff' later.
+    # This is necessary for properly supporting renames as well as whitespaces in file names.
+    get_files="readarray -t files < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/')"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.
     # The string is evaluated a few subsequent times, so we need multiple escapes.
     escaped_commits=${commits//\{/\\\\\{}
-    preview_cmd="$get_files | xargs -I% git diff --color=always -U$_forgit_preview_context $escaped_commits -- % | $_forgit_diff_pager"
-    enter_cmd="$get_files | xargs -I% git diff --color=always -U$_forgit_fullscreen_context $escaped_commits -- % | $_forgit_diff_pager"
+    git_diff="cd '$repo' && git diff --color=always"
+    preview_cmd="$get_files && $git_diff -U$_forgit_preview_context $escaped_commits -- \\\"\${files[@]}\\\" | $_forgit_diff_pager"
+    enter_cmd="$get_files && $git_diff -U$_forgit_fullscreen_context $escaped_commits -- \\\"\${files[@]}\\\" | $_forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -114,7 +114,7 @@ _forgit_diff() {
     repo="$(git rev-parse --show-toplevel)"
     # Store file names into an array so that they can be passed separately to 'git diff' later.
     # This is necessary for properly supporting renames as well as whitespaces in file names.
-    get_files="readarray -t files < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/')"
+    get_files="while read f; do files+=(\$f); done < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/')"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -123,14 +123,15 @@ _forgit_diff() {
     #   file\0another file\0
     #   file with spaces\0
     #   oldfile\0
-    get_files="cd '$repo' && echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\x0/' | sed 's/$/\\\x0/'"
+    get_files="echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\x0/' | sed 's/$/\\\x0/'"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.
     # The string is evaluated a few subsequent times, so we need multiple escapes.
     escaped_commits=${commits//\{/\\\\\{}
-    preview_cmd="$get_files | xargs -0 git diff --color=always -U$_forgit_preview_context $escaped_commits -- | $_forgit_diff_pager"
-    enter_cmd="$get_files | xargs -0 git diff --color=always -U$_forgit_fullscreen_context $escaped_commits -- | $_forgit_diff_pager"
+    git_diff="git diff --color=always $escaped_commits"
+    preview_cmd="cd '$repo' && $get_files | xargs -0 $git_diff -U$_forgit_preview_context -- | $_forgit_diff_pager"
+    enter_cmd="cd '$repo' && $get_files | xargs -0 $git_diff -U$_forgit_fullscreen_context -- | $_forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -123,7 +123,9 @@ _forgit_diff() {
     #   file\0another file\0
     #   file with spaces\0
     #   oldfile\0
-    get_files="echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\x0/' | sed 's/$/\\\x0/'"
+    # We have to do a two-step sed -> tr pipe because OSX's sed implementation does
+    # not support the null-character directly.
+    get_files="echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/' | tr '\\\n' '\\\0'"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -114,17 +114,23 @@ _forgit_diff() {
         fi
     }
     repo="$(git rev-parse --show-toplevel)"
-    # Store file names into an array so that they can be passed separately to 'git diff' later.
-    # This is necessary for properly supporting renames as well as whitespaces in file names.
-    get_files="while IFS= read -r -d '' f; do files+=(\\\"\$f\\\"); done < <(echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\x0/' | sed 's/$/\\\x0/')"
+    # Construct a null-terminated list of the filenames
+    # The input looks like one of these lines:
+    #   [R100]  file  ->  another file
+    #   [A]     file with spaces
+    #   [D]     oldfile
+    # And we transform it to this representation for further usage with "xargs -0":
+    #   file\0another file\0
+    #   file with spaces\0
+    #   oldfile\0
+    get_files="cd '$repo' && echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\x0/' | sed 's/$/\\\x0/'"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.
     # The string is evaluated a few subsequent times, so we need multiple escapes.
     escaped_commits=${commits//\{/\\\\\{}
-    git_diff="cd '$repo' && git diff --color=always"
-    preview_cmd="$get_files && $git_diff -U$_forgit_preview_context $escaped_commits -- \\\"\${files[@]}\\\" | $_forgit_diff_pager"
-    enter_cmd="$get_files && $git_diff -U$_forgit_fullscreen_context $escaped_commits -- \\\"\${files[@]}\\\" | $_forgit_diff_pager"
+    preview_cmd="$get_files | xargs -0 git diff --color=always -U$_forgit_preview_context $escaped_commits -- | $_forgit_diff_pager"
+    enter_cmd="$get_files | xargs -0 git diff --color=always -U$_forgit_fullscreen_context $escaped_commits -- | $_forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

This had been fixed before in #189, but obviously the patch broke support for whitespaces in file names. That was fixed in #204, which in turn broke support for renames again.

Unfortunately we cannot support both cases together with the existing `xargs` implementation, because the arguments are interpreted either as one single file name (which breaks renames, because we have two files passed in this case) or as separate file names (which breaks whitespace support, because git would interpret each word of the file name as a separate file).

This patch moves away from `xargs` and stores the file names in a bash array instead. This makes it possible to pass them to `git diff` quoted one by one using the `"${array[@]}"` notation.

Test environment:

```shell
mkdir test && cd test
git init
touch file && git add file
git commit -m "Initial commit"

touch newfile && git add newfile
touch "file with spaces" && git add "file with spaces"
git mv file "another file"

git forgit diff --staged
```

Before:

![grafik](https://user-images.githubusercontent.com/45259958/215534741-b407b7bb-27c9-493d-a000-a7e5297f2713.png)

After:

![grafik](https://user-images.githubusercontent.com/45259958/215534474-316fc62d-8b70-4493-aa22-64a6b2414760.png)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
