### PR TITLE
#212 Include oh-my-zsh install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ omf install https://github.com/wfxr/forgit
 # for zinit
 zinit load wfxr/forgit
 
+# for oh-my-zsh
+git clone https://github.com/wfxr/forgit.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/forgit
+
 # manually
 # Clone the repository and source it in your shell's rc file or put bin/git-forgit into your $PATH
 ```


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

Saw #212 and thought I'd submit a PR instead of leaving the oh-my-zsh install instructions within an open issue :)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
