### PR TITLE
Fix broken _forgit_cherry_pick

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -289,10 +289,10 @@ _forgit_cherry_pick() {
     [[ -z "$fzf_selection" ]] && return $fzf_exitval
 
     commits=()
-    while IFS="" read -r line
+    while IFS=" " read -r line
     do
         commits+=("$line")
-    done < <(echo "$fzf_selection" | _forgit_reverse_lines | cut -d' ' -f2)
+    done < <(echo "$fzf_selection" | _forgit_reverse_lines)
 
     [ ${#commits[@]} -eq 0 ] && return 1
 


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

I noticed that cherry-picking was broken for me, git always gave me the error message `fatal: bad revision ''`. The issue seems to be with the `cut -d' ' -f2` command which removes all the commit ids (at least for me).
I've refactored the code to use the read commands internal field separation instead. Would be especially courious to know if this works fine on your environment @cjappl, since you implemented the original functionality and I guess there might be some incompatibility between macOS and Linux at play here.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
