### PR TITLE
Detect unexported variables in fish correctly (Fix #289)

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -7,14 +7,14 @@ if [ ! -e "$FORGIT" ]
 end
 
 function forgit::warn
-    printf "%b[Warn]%b %s\n" '\e[0;33m' '\e[0m' "$argv" >&2;
+    printf "%b[Warn]%b %s\n" '\e[0;33m' '\e[0m' "$argv" >&2
 end
 
 # backwards compatibility:
 # export all user-defined FORGIT variables to make them available in git-forgit
 set unexported_vars 0
 set | awk -F ' ' '{ print $1 }' | grep FORGIT_ | while read var
-    if ! set -x | grep -q "^$var "
+    if not set -x | grep -q "^$var\b"
         if test $unexported_vars = 0
             forgit::warn "Config options have to be exported in future versions of forgit."
             forgit::warn "Please update your config accordingly:"


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

See #289 for the complete details

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
