### PR TITLE
Only show available cherry picks in preview

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -315,13 +315,17 @@ _forgit_cherry_pick() {
 
 _forgit_cherry_pick_from_branch() {
     _forgit_inside_work_tree || return 1
-    local cmd preview opts branch exitval input_branch args
+    local cmd preview opts branch exitval input_branch args base
+
+    base=$(git branch --show-current)
+    [[ -z "$base" ]] && echo "Current commit is not on a branch." && return 1
+
     args=("$@")
     if [[ $# -ne 0 ]]; then
         input_branch=${args[0]}
     fi
     cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
-    preview="git log {1} $_forgit_log_preview_options"
+    preview="git log --right-only --color=always --cherry-pick --oneline $base...{1}"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index --header-lines=1


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

This is a follow-up to #266, which already switched to showing only available commits during cherry-picking. This patch does the same for the branch preview in `_forgit_cherry_pick_from_branch`.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
