### PR TITLE
Fix broken cherry picking

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -296,18 +296,16 @@ _forgit_cherry_pick() {
         --multi --ansi --with-nth 2.. -0 --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
+    # Note: do not add any pipe after the fzf call here, otherwise the fzf_exitval is not propagated properly.
+    # Any eventual post processing can be done afterwards when the "commits" variable is assigned below.
     fzf_selection=$(git log --right-only --color=always --cherry-pick --oneline "$base"..."$target" | nl |
-        FZF_DEFAULT_OPTS="$opts" fzf | sort --numeric-sort --key=1 | cut -f 2- | cut -c 1-8)
+        FZF_DEFAULT_OPTS="$opts" fzf)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
     [[ -z "$fzf_selection" ]] && return $fzf_exitval
 
-    commits=()
-    while IFS="" read -r line
-    do
-        commits+=("$line")
-    done < <(echo "$fzf_selection" | _forgit_reverse_lines | cut -d' ' -f2)
-
+    # shellcheck disable=2207
+    IFS=$'\n' commits=($(echo "$fzf_selection" | sort --numeric-sort --key=1 | cut -f2 | cut -d' ' -f1 | _forgit_reverse_lines))
     [ ${#commits[@]} -eq 0 ] && return 1
 
     git cherry-pick "${commits[@]}"


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

With the changes of #261 and #266 we accidentally broke the return value of `_forgit_cherry_pick`, which led to the loop in `_forgit_cherry_pick_from_branch` being terminated in the wrong cases. Fix this by moving all the post processing after fzf to a later call.

Also simplify the array population using a single line instead of a loop.

This should also fix #286 ("fatal: bad revision ''").

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
