### PR TITLE
Add keybinding ctrl+y for copying stash ID in gss

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ Install `forgit` in just one click.
 | <kbd>Alt</kbd> - <kbd>W</kbd>                 | Toggle preview wrap       |
 | <kbd>Ctrl</kbd> - <kbd>S</kbd>                | Toggle sort               |
 | <kbd>Ctrl</kbd> - <kbd>R</kbd>                | Toggle selection          |
-| <kbd>Ctrl</kbd> - <kbd>Y</kbd>                | Copy commit hash*         |
+| <kbd>Ctrl</kbd> - <kbd>Y</kbd>                | Copy commit hash/stash ID*|
 | <kbd>Ctrl</kbd> - <kbd>K</kbd> / <kbd>P</kbd> | Selection move up         |
 | <kbd>Ctrl</kbd> - <kbd>J</kbd> / <kbd>N</kbd> | Selection move down       |
 | <kbd>Alt</kbd> - <kbd>K</kbd> / <kbd>P</kbd>  | Preview move up           |
 | <kbd>Alt</kbd> - <kbd>J</kbd> / <kbd>N</kbd>  | Preview move down         |
 
-\* Available when the selection contains a commit hash.
+\* Available when the selection contains a commit hash or a stash ID.
 For linux users `FORGIT_COPY_CMD` should be set to make copy work. Example: `FORGIT_COPY_CMD='xclip -selection clipboard'`.
 
 ### ⚙  Options

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -213,6 +213,7 @@ _forgit_stash_show() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m -0 --tiebreak=index --bind=\"enter:execute($cmd | $_forgit_enter_pager)\"
+        --bind=\"ctrl-y:execute-silent(echo {} | cut -d: -f1 | tr -d '[:space:]' | ${FORGIT_COPY_CMD:-pbcopy})\"
         --preview=\"$cmd\"
         $FORGIT_STASH_FZF_OPTS
     "


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

Add keybinding `ctrl+y` for copying stash ID in `gss`.

Fixes #287.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
