### PR TITLE
Fix temporary IFS settings

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -313,8 +313,10 @@ _forgit_cherry_pick() {
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
     [[ -z "$fzf_selection" ]] && return $fzf_exitval
 
+    old_IFS=$IFS IFS=$'\n' 
     # shellcheck disable=2207
-    IFS=$'\n' commits=($(echo "$fzf_selection" | sort --numeric-sort --key=1 | cut -f2 | cut -d' ' -f1 | _forgit_reverse_lines))
+    commits=($(echo "$fzf_selection" | sort --numeric-sort --key=1 | cut -f2 | cut -d' ' -f1 | _forgit_reverse_lines))
+    IFS=${old_IFS}
     [ ${#commits[@]} -eq 0 ] && return 1
 
     $git_cherry_pick "${commits[@]}"
@@ -550,13 +552,15 @@ _forgit_revert_commit() {
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
     preview="echo {} | cut -f2- | $_forgit_extract_sha | xargs -I% git show --color=always % -- $files | $_forgit_show_pager"
 
+    old_IFS=$IFS IFS=$'\n' 
     # shellcheck disable=2207
-    IFS=$'\n' commits=($(eval "$cmd" | 
+    commits=($(eval "$cmd" | 
         nl |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" -m | 
         sort --numeric-sort --key=1 | 
         cut -f2- |
         sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/'))
+    IFS=${old_IFS}
 
     [ ${#commits[@]} -eq 0 ] && return 1
 
@@ -602,9 +606,11 @@ _forgit_ignore() {
         --preview=\"eval $cmd\"
         $FORGIT_IGNORE_FZF_OPTS
     "
+    old_IFS=$IFS IFS=$'\n' 
     # shellcheck disable=SC2206,2207
-    IFS=$'\n' args=($@) && [[ $# -eq 0 ]] && args=($(_forgit_ignore_list | nl -nrn -w4 -s'  ' |
+    args=($@) && [[ $# -eq 0 ]] && args=($(_forgit_ignore_list | nl -nrn -w4 -s'  ' |
         FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}'))
+    IFS=${old_IFS}
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     _forgit_ignore_get ${args[@]}


### PR DESCRIPTION
When setting the IFS for a certain command only, the command must not be an assignment, otherwise both assignments are evaluated permanently (see https://unix.stackexchange.com/a/458901/317320).

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
