### PR TITLE
feat: Use fzf-tmux if fzf options are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,6 @@ Install `forgit` in just one click.
 
 [![Install with Fig](https://fig.io/badges/install-with-fig.svg)](https://fig.io/plugins/other/forgit)
 
-### `fzf-tmux` support
-
-If `FZF_TMUX` is not 0, or if `FZF_TMUX_OPTS` are set, then `forgit` will use `fzf-tmux`.
-
-More information can be found in [the fzf README](https://github.com/junegunn/fzf#fzf-tmux-script).
-
-If you use a command that can return no results, for example `gd`, and you are using `fzf-tmux`, you might
-see flicker as the pane or popup is opened and then closed. Setting the variable `FORGIT_FZF_SHOW_NO_MATCHES=1`
-will leave the open pane or popup window open. This might be useful if you don't like the flicker or if you
-need to make sure that `fzf` or `forgit` aren't closing for other reasons.
-
 ### 📝 Features
 
 - **Interactive `git add` selector** (`ga`)
@@ -317,6 +306,17 @@ export FORGIT_LOG_FZF_OPTS='
 | `FORGIT_LOG_FORMAT`         | git log format                           | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
 | `FORGIT_PREVIEW_CONTEXT`    | lines of diff context in preview mode    | 3                                             |
 | `FORGIT_FULLSCREEN_CONTEXT` | lines of diff context in fullscreen mode | 10                                            |
+### `fzf-tmux` support
+
+If `FZF_TMUX` is not 0, or if `FZF_TMUX_OPTS` are set, then `forgit` will use `fzf-tmux`.
+
+More information can be found in [the fzf README](https://github.com/junegunn/fzf#fzf-tmux-script).
+
+If you use a command that can return no results, for example `gd`, and you are using `fzf-tmux`, you might
+see flicker as the pane or popup is opened and then closed. Setting the variable `FORGIT_FZF_SHOW_NO_MATCHES=1`
+will leave the open pane or popup window open. This might be useful if you don't like the flicker or if you
+need to make sure that `fzf` or `forgit` aren't closing for other reasons.
+
 
 ### 📦 Optional dependencies
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Install `forgit` in just one click.
 
 [![Install with Fig](https://fig.io/badges/install-with-fig.svg)](https://fig.io/plugins/other/forgit)
 
+### `fzf-tmux` support
+
+If `FZF_TMUX` is not 0, or if `FZF_TMUX_OPTS` are set, then `forgit` will use `fzf-tmux`.
+
+More information can be found in [the fzf README](https://github.com/junegunn/fzf#fzf-tmux-script).
+
+When `fzf-tmux` is used, the "Exit if no matches" behavior is disabled because it can cause flicker
+with the tmux popup window. If you'd rather not see the empty pane or popup when using `fzf-tmux`,
+you can add `--exit-0` or `-0` to `FZF_TMUX_OPTS` to get the immediate close behavior with slight
+flicker.
+
 ### 📝 Features
 
 - **Interactive `git add` selector** (`ga`)

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ If `FZF_TMUX` is not 0, or if `FZF_TMUX_OPTS` are set, then `forgit` will use `f
 
 More information can be found in [the fzf README](https://github.com/junegunn/fzf#fzf-tmux-script).
 
-When `fzf-tmux` is used, the "Exit if no matches" behavior is disabled because it can cause flicker
-with the tmux popup window. If you'd rather not see the empty pane or popup when using `fzf-tmux`,
-you can add `--exit-0` or `-0` to `FZF_TMUX_OPTS` to get the immediate close behavior with slight
-flicker.
+If you use a command that can return no results, for example `gd`, and you are using `fzf-tmux`, you might
+see flicker as the pane or popup is opened and then closed. Setting the variable `FORGIT_FZF_SHOW_NO_MATCHES=1`
+will leave the open pane or popup window open. This might be useful if you don't like the flicker or if you
+need to make sure that `fzf` or `forgit` aren't closing for other reasons.
 
 ### 📝 Features
 

--- a/README.md
+++ b/README.md
@@ -301,22 +301,12 @@ export FORGIT_LOG_FZF_OPTS='
 
 #### other options
 
-| Option                      | Description                              | Default                                       |
-|-----------------------------|------------------------------------------|-----------------------------------------------|
-| `FORGIT_LOG_FORMAT`         | git log format                           | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
-| `FORGIT_PREVIEW_CONTEXT`    | lines of diff context in preview mode    | 3                                             |
-| `FORGIT_FULLSCREEN_CONTEXT` | lines of diff context in fullscreen mode | 10                                            |
-### `fzf-tmux` support
-
-If `FZF_TMUX` is not 0, or if `FZF_TMUX_OPTS` are set, then `forgit` will use `fzf-tmux`.
-
-More information can be found in [the fzf README](https://github.com/junegunn/fzf#fzf-tmux-script).
-
-If you use a command that can return no results, for example `gd`, and you are using `fzf-tmux`, you might
-see flicker as the pane or popup is opened and then closed. Setting the variable `FORGIT_FZF_SHOW_NO_MATCHES=1`
-will leave the open pane or popup window open. This might be useful if you don't like the flicker or if you
-need to make sure that `fzf` or `forgit` aren't closing for other reasons.
-
+| Option                          | Description                                          | Default                                           |
+|---------------------------------|------------------------------------------------------|---------------------------------------------------|
+| `FORGIT_LOG_FORMAT`             | git log format                                       | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset`     |
+| `FORGIT_PREVIEW_CONTEXT`        | lines of diff context in preview mode                | 3                                                 |
+| `FORGIT_FULLSCREEN_CONTEXT`     | lines of diff context in fullscreen mode             | 10                                                |
+| `FORGIT_SHOW_FZF_ON_EMPTY_LIST` | if set to `1` then *do not* pass `--exit-0` to `fzf` | 0                                                 |
 
 ### 📦 Optional dependencies
 
@@ -325,6 +315,9 @@ need to make sure that `fzf` or `forgit` aren't closing for other reasons.
 - [`bat`](https://github.com/sharkdp/bat.git): Syntax highlighting for `gitignore`.
 
 - [`emoji-cli`](https://github.com/wfxr/emoji-cli): Emoji support for `git log`.
+
+- [`fzf-tmux`](https://github.com/junegunn/fzf#fzf-tmux-script): `forgit` will integrate with `fzf-tmux` if the appropriate `fzf` options are set.
+  - When a command receives no input (such as `gd` with no changes) then `fzf-tmux` may flicker. If you find that troublesome, one workaround is the `FORGIT_SHOW_FZF_ON_EMPTY_LIST` [option](#other-options)
 
 ### 💡 Tips
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -195,13 +195,14 @@ _forgit_add() {
         sed 's/^.*]  //' |
         sed 's/.* -> //' |
         sed -e 's/^\\\"//' -e 's/\\\"\$//'"
-    preview="
+    preview_cmd="
         file=\$(echo {} | $extract)
         if (git status -s -- \\\"\$file\\\" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
             git diff --color=always --no-index -- /dev/null \\\"\$file\\\" | $_forgit_diff_pager | sed '2 s/added:/untracked:/'
         else
             git diff --color=always -- \\\"\$file\\\" | $_forgit_diff_pager
         fi"
+    preview="bash -c $preview_cmd"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m --nth 2..,..

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -46,7 +46,7 @@ ${FORGIT_FZF_DEFAULT_OPTS}
 fi
 
 FORGIT_USE_FZF_TMUX=0
-if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" || "${FORGIT_FZF_TMUX_OPTS}"]; }; then
+if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" ] ||[ -n "${FORGIT_FZF_TMUX_OPTS-}" ]; }; then
     FORGIT_FZF_TMUX_OPTS="${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} ${FORGIT_FZF_TMUX_OPTS}"
     FORGIT_USE_FZF_TMUX=1
 fi

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -31,7 +31,7 @@ do_fzf() {
   if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" ]; }; then
    # We don't hardcode --exit-0 here because it causes flicker when using
    # tmux + popups instead of panes. Could be revisited.
-   fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} "$@"
+   fzf-tmux "${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}}" "$@"
   else
    fzf -0 "$@"
   fi

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -39,15 +39,15 @@ $FORGIT_FZF_DEFAULT_OPTS
 
 # If FORGIT_FZF_SHOW_NO_MATCHES is 1, then we don't pass `--exit-0` to fzf/fzf-tmux.
 if [ "${FORGIT_FZF_SHOW_NO_MATCHES:-0}" != 1 ]; then
-    FORGIT_FZF_DEFAULT_OPTS="--exit-0 $FORGIT_FZF_DEFAULT_OPTS"
+    FORGIT_FZF_DEFAULT_OPTS="
+${FORGIT_FZF_DEFAULT_OPTS}
+--exit-0
+"
 fi
 
 FORGIT_USE_FZF_TMUX=0
 if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" || "${FORGIT_FZF_TMUX_OPTS}"]; }; then
-    FORGIT_FZF_TMUX_OPTS="
-    ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}}
-    $FORGIT_FZF_TMUX_OPTS
-    "
+    FORGIT_FZF_TMUX_OPTS="${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} ${FORGIT_FZF_TMUX_OPTS}"
     FORGIT_USE_FZF_TMUX=1
 fi
 
@@ -58,8 +58,9 @@ fi
 # While the fzf docs say that `fzf-tmux` is safe to use in scripts even outside
 # of a tmux session, we still employ defensive variable tests.
 do_fzf() {
+    export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS"
     if [ "${FORGIT_USE_FZF_TMUX}" == 1 ]; then
-        fzf-tmux "${FORGIT_FZF_TMUX_OPTS}" -- ${FZF_DEFAULT_OPTS} "$@"
+        fzf-tmux "$FORGIT_FZF_TMUX_OPTS" "$@"
     else
         fzf "$@"
     fi

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -22,22 +22,6 @@ export SHELL
 # Get absolute forgit path
 FORGIT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/$(basename -- "${BASH_SOURCE[0]}")
 
-# This function provides an abstraction for conditionally invoking
-# either `fzf` or `fzf-tmux` depending on the state of the current shell.
-#
-# While the fzf docs say that `fzf-tmux` is safe to use in scripts even outside
-# of a tmux session, we still employ defensive variable tests.
-do_fzf() {
-  if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" ]; }; then
-   # We don't hardcode --exit-0 here because it causes flicker when using
-   # tmux + popups instead of panes. Could be revisited.
-   fzf-tmux "${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}}" "$@"
-  else
-   fzf -0 "$@"
-  fi
-}
-
-
 FORGIT_FZF_DEFAULT_OPTS="
 $FZF_DEFAULT_OPTS
 --ansi
@@ -52,6 +36,34 @@ $FZF_DEFAULT_OPTS
 +1
 $FORGIT_FZF_DEFAULT_OPTS
 "
+
+# If FORGIT_FZF_SHOW_NO_MATCHES is 1, then we don't pass `--exit-0` to fzf/fzf-tmux.
+if [ "${FORGIT_FZF_SHOW_NO_MATCHES:-0}" != 1 ]; then
+    FORGIT_FZF_DEFAULT_OPTS="--exit-0 $FORGIT_FZF_DEFAULT_OPTS"
+fi
+
+FORGIT_USE_FZF_TMUX=0
+if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" || "${FORGIT_FZF_TMUX_OPTS}"]; }; then
+    FORGIT_FZF_TMUX_OPTS="
+    ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}}
+    $FORGIT_FZF_TMUX_OPTS
+    "
+    FORGIT_USE_FZF_TMUX=1
+fi
+
+
+# This function provides an abstraction for conditionally invoking
+# either `fzf` or `fzf-tmux` depending on the state of the current shell.
+#
+# While the fzf docs say that `fzf-tmux` is safe to use in scripts even outside
+# of a tmux session, we still employ defensive variable tests.
+do_fzf() {
+    if [ "${FORGIT_USE_FZF_TMUX}" == 1 ]; then
+        fzf-tmux "${FORGIT_FZF_TMUX_OPTS}" -- ${FZF_DEFAULT_OPTS} "$@"
+    else
+        fzf "$@"
+    fi
+}
 
 _forgit_warn() { printf "%b[Warn]%b %s\n" '\e[0;33m' '\e[0m' "$@" >&2; }
 _forgit_info() { printf "%b[Info]%b %s\n" '\e[0;32m' '\e[0m' "$@" >&2; }
@@ -191,7 +203,7 @@ _forgit_add() {
         fi"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        -0 -m --nth 2..,..
+        -m --nth 2..,..
         --preview=\"$preview\"
         $FORGIT_ADD_FZF_OPTS
     "
@@ -213,7 +225,7 @@ _forgit_reset_head() {
     cmd="git diff --staged --color=always -- $rootdir/{} | $_forgit_diff_pager "
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        -m -0
+        -m
         --preview=\"$cmd\"
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
@@ -231,7 +243,7 @@ _forgit_stash_show() {
     cmd="echo {} |cut -d: -f1 |xargs -I% git stash show --color=always --ext-diff % |$_forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m -0 --tiebreak=index --bind=\"enter:execute($cmd | $_forgit_enter_pager)\"
+        +s +m --tiebreak=index --bind=\"enter:execute($cmd | $_forgit_enter_pager)\"
         --bind=\"ctrl-y:execute-silent(echo {} | cut -d: -f1 | tr -d '[:space:]' | ${FORGIT_COPY_CMD:-pbcopy})\"
         --preview=\"$cmd\"
         $FORGIT_STASH_FZF_OPTS
@@ -288,7 +300,7 @@ _forgit_clean() {
     git_clean="git clean $FORGIT_CLEAN_GIT_OPTS"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        -m -0
+        -m
         $FORGIT_CLEAN_FZF_OPTS
     "
     # Note: Postfix '/' in directory path should be removed. Otherwise the directory itself will not be removed.
@@ -318,7 +330,7 @@ _forgit_cherry_pick() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         --preview=\"$preview\"
-        --multi --ansi --with-nth 2.. -0 --tiebreak=index
+        --multi --ansi --with-nth 2.. --tiebreak=index
         $FORGIT_CHERRY_PICK_FZF_OPTS
     "
     # Note: do not add any pipe after the fzf call here, otherwise the fzf_exitval is not propagated properly.
@@ -438,7 +450,7 @@ _forgit_checkout_file() {
     cmd="git diff --color=always -- {} | $_forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        -m -0
+        -m 
         --preview=\"$cmd\"
         $FORGIT_CHECKOUT_FILE_FZF_OPTS
     "

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -19,9 +19,17 @@
 # shellcheck disable=2230
 SHELL="$(which bash)"
 export SHELL
-
 # Get absolute forgit path
 FORGIT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/$(basename -- "${BASH_SOURCE[0]}")
+
+do_fzf() {
+  if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" ]; }; then
+   fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} "$@"
+  else
+   fzf -0 "$@"
+  fi
+}
+
 
 FORGIT_FZF_DEFAULT_OPTS="
 $FZF_DEFAULT_OPTS
@@ -91,7 +99,7 @@ _forgit_log() {
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
     log_format=${FORGIT_GLO_FORMAT:-$_forgit_log_format}
     eval "git log $graph --color=always --format='$log_format' $FORGIT_LOG_GIT_OPTS $* $_forgit_emojify" |
-        FZF_DEFAULT_OPTS="$opts" fzf
+        FZF_DEFAULT_OPTS="$opts" do_fzf
     fzf_exit_code=$?
     # exit successfully on 130 (ctrl-c/esc)
     [[ $fzf_exit_code == 130 ]] && return 0
@@ -136,14 +144,14 @@ _forgit_diff() {
     enter_cmd="cd '$repo' && $get_files | xargs -0 $git_diff -U$_forgit_fullscreen_context -- | $_forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +m -0 --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"
+        +m --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"
         --preview=\"$preview_cmd\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"$commits > \"
     "
     eval "git diff --name-status $FORGIT_DIFF_GIT_OPTS $commits -- ${files[*]} | sed -E 's/^([[:alnum:]]+)[[:space:]]+(.*)$/[\1]	\2/'" |
         sed 's/	/  ->  /2' | expand -t 8 |
-        FZF_DEFAULT_OPTS="$opts" fzf
+        FZF_DEFAULT_OPTS="$opts" do_fzf
     fzf_exit_code=$?
     # exit successfully on 130 (ctrl-c/esc)
     [[ $fzf_exit_code == 130 ]] && return 0
@@ -183,7 +191,7 @@ _forgit_add() {
     files=$(git -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
-        FZF_DEFAULT_OPTS="$opts" fzf |
+        FZF_DEFAULT_OPTS="$opts" do_fzf |
         sh -c "$extract")
     [[ -n "$files" ]] && echo "$files"| tr '\n' '\0' | $git_add --pathspec-file-nul --pathspec-from-file - && git status -su && return
     echo 'Nothing to add.'
@@ -202,7 +210,7 @@ _forgit_reset_head() {
         --preview=\"$cmd\"
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
-    files="$(git diff --staged --name-only | FZF_DEFAULT_OPTS="$opts" fzf)"
+    files="$(git diff --staged --name-only | FZF_DEFAULT_OPTS="$opts" do_fzf)"
     # shellcheck disable=2086
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% $git_reset_head "$rootdir"/% && git status --short && return
     echo 'Nothing to unstage.'
@@ -221,7 +229,7 @@ _forgit_stash_show() {
         --preview=\"$cmd\"
         $FORGIT_STASH_FZF_OPTS
     "
-    $git_stash_list | FZF_DEFAULT_OPTS="$opts" fzf
+    $git_stash_list | FZF_DEFAULT_OPTS="$opts" do_fzf
     fzf_exit_code=$?
     # exit successfully on 130 (ctrl-c/esc)
     [[ $fzf_exit_code == 130 ]] && return 0
@@ -261,7 +269,7 @@ _forgit_stash_push() {
         fi
     "
     # Show both modified and untracked files
-    files=$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
+    files=$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" do_fzf --preview="$preview")
     [[ -z "$files" ]] && return 1
     echo "${files[@]}" | tr '\n' '\0' | $git_stash_push ${msg:+-m "$msg"} -u --pathspec-file-nul --pathspec-from-file -
 }
@@ -277,7 +285,7 @@ _forgit_clean() {
         $FORGIT_CLEAN_FZF_OPTS
     "
     # Note: Postfix '/' in directory path should be removed. Otherwise the directory itself will not be removed.
-    files=$(git clean -xdffn "$@"| sed 's/^Would remove //' | FZF_DEFAULT_OPTS="$opts" fzf |sed 's#/$##')
+    files=$(git clean -xdffn "$@"| sed 's/^Would remove //' | FZF_DEFAULT_OPTS="$opts" do_fzf |sed 's#/$##')
     # shellcheck disable=2086
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% $git_clean -xdff '%' && git status --short && return
     echo 'Nothing to clean.'
@@ -294,7 +302,7 @@ _forgit_cherry_pick() {
     [[ -z $1 ]] && echo "Please specify target branch" && return 1
     target="$1"
 
-    # in this function, we do something interesting to maintain proper ordering as it's assumed 
+    # in this function, we do something interesting to maintain proper ordering as it's assumed
     # you generally want to cherry pick oldest->newest when you multiselect
     # The instances of "cut", "nl" and "sort" all serve this purpose
     # Please see https://github.com/wfxr/forgit/issues/253 for more details
@@ -309,7 +317,7 @@ _forgit_cherry_pick() {
     # Note: do not add any pipe after the fzf call here, otherwise the fzf_exitval is not propagated properly.
     # Any eventual post processing can be done afterwards when the "commits" variable is assigned below.
     fzf_selection=$(git log --right-only --color=always --cherry-pick --oneline "$base"..."$target" | nl |
-        FZF_DEFAULT_OPTS="$opts" fzf)
+        FZF_DEFAULT_OPTS="$opts" do_fzf)
     fzf_exitval=$?
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
     [[ -z "$fzf_selection" ]] && return $fzf_exitval
@@ -348,7 +356,7 @@ _forgit_cherry_pick_from_branch() {
     while true
     do
         if [[ -z $input_branch ]]; then
-            branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')"
+            branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" do_fzf | awk '{print $1}')"
         else
             branch=$input_branch
         fi
@@ -379,7 +387,7 @@ _forgit_rebase() {
         --preview=\"$preview\"
         $FORGIT_REBASE_FZF_OPTS
     "
-    target_commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | eval "$_forgit_extract_sha")
+    target_commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" do_fzf | eval "$_forgit_extract_sha")
     if [[ -n "$target_commit" ]]; then
         prev_commit=$(_forgit_previous_commit "$target_commit")
 
@@ -404,7 +412,7 @@ _forgit_fixup() {
         --preview=\"$preview\"
         $FORGIT_FIXUP_FZF_OPTS
     "
-    target_commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | eval "$_forgit_extract_sha")
+    target_commit=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" do_fzf | eval "$_forgit_extract_sha")
     if [[ -n "$target_commit" ]] && $git_fixup "$target_commit"; then
         prev_commit=$(_forgit_previous_commit "$target_commit")
         # rebase will fail if there are unstaged changes so --autostash is needed to temporarily stash them
@@ -427,7 +435,7 @@ _forgit_checkout_file() {
         --preview=\"$cmd\"
         $FORGIT_CHECKOUT_FILE_FZF_OPTS
     "
-    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf)"
+    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" do_fzf)"
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | $git_checkout --pathspec-file-nul --pathspec-from-file -
 }
 
@@ -455,7 +463,7 @@ _forgit_checkout_branch() {
         --preview=\"$preview\"
         $FORGIT_CHECKOUT_BRANCH_FZF_OPTS
         "
-    branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')"
+    branch="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" do_fzf | awk '{print $1}')"
     [[ -z "$branch" ]] && return 1
 
     git_checkout="git checkout $FORGIT_CHECKOUT_BRANCH_GIT_OPTS"
@@ -486,7 +494,7 @@ _forgit_checkout_tag() {
         --preview=\"$preview\"
         $FORGIT_CHECKOUT_TAG_FZF_OPTS
     "
-    tag="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf)"
+    tag="$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" do_fzf)"
     [[ -z "$tag" ]] && return 1
     $git_checkout "$tag"
 }
@@ -509,7 +517,7 @@ _forgit_checkout_commit() {
     [[ $FORGIT_LOG_GRAPH_ENABLE == false ]] && graph=
     # shellcheck disable=2086
     eval "git log $graph --color=always --format='$_forgit_log_format' $_forgit_emojify" |
-        FZF_DEFAULT_OPTS="$opts" fzf | eval "$_forgit_extract_sha" | xargs -I% $git_checkout % --
+        FZF_DEFAULT_OPTS="$opts" do_fzf | eval "$_forgit_extract_sha" | xargs -I% $git_checkout % --
 }
 
 _forgit_branch_delete() {
@@ -526,7 +534,7 @@ _forgit_branch_delete() {
     "
 
     cmd="git branch --color=always | LC_ALL=C sort -k1.1,1.1 -rs"
-    branches=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $1}')
+    branches=$(eval "$cmd" | FZF_DEFAULT_OPTS="$opts" do_fzf | awk '{print $1}')
     # shellcheck disable=2086
     echo -n "$branches" | tr '\n' '\0' | xargs -I{} -0 $git_branch -D {}
 }
@@ -546,7 +554,7 @@ _forgit_revert_commit() {
         $FORGIT_REVERT_COMMIT_FZF_OPTS
     "
 
-    # in this function, we do something interesting to maintain proper ordering as it's assumed 
+    # in this function, we do something interesting to maintain proper ordering as it's assumed
     # you generally want to revert newest->oldest when you multiselect
     # The instances of "cut", "nl" and "sort" all serve this purpose
     # Please see https://github.com/wfxr/forgit/issues/253 for more details
@@ -557,10 +565,10 @@ _forgit_revert_commit() {
     ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
     IFS=$'\n'
     # shellcheck disable=2207
-    commits=($(eval "$cmd" | 
+    commits=($(eval "$cmd" |
         nl |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview" -m | 
-        sort --numeric-sort --key=1 | 
+        FZF_DEFAULT_OPTS="$opts" do_fzf --preview="$preview" -m |
+        sort --numeric-sort --key=1 |
         cut -f2- |
         sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/'))
     ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
@@ -588,7 +596,7 @@ _forgit_blame() {
             echo File not tracked
         fi
     "
-    file=$(FZF_DEFAULT_OPTS="$opts" fzf --preview="$preview")
+    file=$(FZF_DEFAULT_OPTS="$opts" do_fzf --preview="$preview")
     [[ -z "$file" ]] && return 1
     # shellcheck disable=2086
     eval $git_blame "$file" "$flags"
@@ -613,7 +621,7 @@ _forgit_ignore() {
     IFS=$'\n'
     # shellcheck disable=SC2206,2207
     args=($@) && [[ $# -eq 0 ]] && args=($(_forgit_ignore_list | nl -nrn -w4 -s'  ' |
-        FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}'))
+        FZF_DEFAULT_OPTS="$opts" do_fzf | awk '{print $2}'))
     ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -22,8 +22,15 @@ export SHELL
 # Get absolute forgit path
 FORGIT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)/$(basename -- "${BASH_SOURCE[0]}")
 
+# This function provides an abstraction for conditionally invoking
+# either `fzf` or `fzf-tmux` depending on the state of the current shell.
+#
+# While the fzf docs say that `fzf-tmux` is safe to use in scripts even outside
+# of a tmux session, we still employ defensive variable tests.
 do_fzf() {
   if [ -n "${TMUX_PANE-}" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "${FZF_TMUX_OPTS-}" ]; }; then
+   # We don't hardcode --exit-0 here because it causes flicker when using
+   # tmux + popups instead of panes. Could be revisited.
    fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} "$@"
   else
    fzf -0 "$@"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -37,8 +37,8 @@ $FZF_DEFAULT_OPTS
 $FORGIT_FZF_DEFAULT_OPTS
 "
 
-# If FORGIT_FZF_SHOW_NO_MATCHES is 1, then we don't pass `--exit-0` to fzf/fzf-tmux.
-if [ "${FORGIT_FZF_SHOW_NO_MATCHES:-0}" != 1 ]; then
+# If FORGIT_SHOW_FZF_ON_EMPTY_LIST is 1, then we don't pass `--exit-0` to fzf/fzf-tmux.
+if [ "${FORGIT_SHOW_FZF_ON_EMPTY_LIST:-0}" != 1 ]; then
     FORGIT_FZF_DEFAULT_OPTS="
 ${FORGIT_FZF_DEFAULT_OPTS}
 --exit-0


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

## Overview

The meat of this change is to inspect whether or not we are in a `tmux` pane, and if so, we check the `FZF_TMUX` and `FZF_TMUX_OPTS` variables. If those are set, we use `fzf-tmux` instead of `fzf` and we forward the appropriate options.

This resolves #303 

## Changes
- Add a `do_fzf` function for abstracting fzf invocation based on shell state as outlined above

- Only hardcode `-0`/`--exit-0` for `fzf`, as it causes flicker w/ tmux popup

- Replace all invocations of `fzf` with `do_fzf`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
