### PR TITLE
Use correct IFS store/restore mechanism

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -314,10 +314,11 @@ _forgit_cherry_pick() {
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
     [[ -z "$fzf_selection" ]] && return $fzf_exitval
 
-    old_IFS=$IFS IFS=$'\n' 
+    ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
+    IFS=$'\n'
     # shellcheck disable=2207
     commits=($(echo "$fzf_selection" | sort --numeric-sort --key=1 | cut -f2 | cut -d' ' -f1 | _forgit_reverse_lines))
-    IFS=${old_IFS}
+    ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
     [ ${#commits[@]} -eq 0 ] && return 1
 
     $git_cherry_pick "${commits[@]}"
@@ -553,7 +554,8 @@ _forgit_revert_commit() {
     files=$(sed -nE 's/.* -- (.*)/\1/p' <<< "$*") # extract files parameters for `git show` command
     preview="echo {} | cut -f2- | $_forgit_extract_sha | xargs -I% git show --color=always % -- $files | $_forgit_show_pager"
 
-    old_IFS=$IFS IFS=$'\n' 
+    ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
+    IFS=$'\n'
     # shellcheck disable=2207
     commits=($(eval "$cmd" | 
         nl |
@@ -561,7 +563,7 @@ _forgit_revert_commit() {
         sort --numeric-sort --key=1 | 
         cut -f2- |
         sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/'))
-    IFS=${old_IFS}
+    ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
 
     [ ${#commits[@]} -eq 0 ] && return 1
 
@@ -607,11 +609,12 @@ _forgit_ignore() {
         --preview=\"eval $cmd\"
         $FORGIT_IGNORE_FZF_OPTS
     "
-    old_IFS=$IFS IFS=$'\n' 
+    ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
+    IFS=$'\n'
     # shellcheck disable=SC2206,2207
     args=($@) && [[ $# -eq 0 ]] && args=($(_forgit_ignore_list | nl -nrn -w4 -s'  ' |
         FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}'))
-    IFS=${old_IFS}
+    ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     _forgit_ignore_get ${args[@]}


### PR DESCRIPTION
The previous implementation had the problem that if IFS was not set before, it was set to an empty string after restoring, which is not the same as being unset. This broke grc / git forgit revert_commit, since "git revert" was being interpreted as the command name instead of command and argument.

The correct way is to check whether IFS is unset and, if so, unset it again afterwards.

See for reference:
https://unix.stackexchange.com/a/264947/317320

Fix #301.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
