### PR TITLE
Allow configuration of checkout_branch branch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,26 +201,25 @@ git cf
 If you want to customize `git`'s behavior within forgit there is a dedicated variable for each forgit command.
 These are passed to the according `git` calls.
 
-| Command  | Option                            |
-|----------|-----------------------------------|
-| `ga`     | `FORGIT_ADD_GIT_OPTS`             |
-| `glo`    | `FORGIT_LOG_GIT_OPTS`             |
-| `gd`     | `FORGIT_DIFF_GIT_OPTS`            |
-| `grh`    | `FORGIT_RESET_HEAD_GIT_OPTS`      |
-| `gcf`    | `FORGIT_CHECKOUT_FILE_GIT_OPTS`   |
-| `gcb`    | `FORGIT_CHECKOUT_BRANCH_GIT_OPTS` |
-| `gbd`    | `FORGIT_BRANCH_DELETE_GIT_OPTS`   |
-| `gct`    | `FORGIT_CHECKOUT_TAG_GIT_OPTS`    |
-| `gco`    | `FORGIT_CHECKOUT_COMMIT_GIT_OPTS` |
-| `grc`    | `FORGIT_REVERT_COMMIT_GIT_OPTS`   |
-| `gss`    | `FORGIT_STASH_SHOW_GIT_OPTS`      |
-| `gsp`    | `FORGIT_STASH_PUSH_GIT_OPTS`      |
-| `gclean` | `FORGIT_CLEAN_GIT_OPTS`           |
-| `grb`    | `FORGIT_REBASE_GIT_OPTS`          |
-| `gbl`    | `FORGIT_BLAME_GIT_OPTS`           |
-| `gfu`    | `FORGIT_FIXUP_GIT_OPTS`           |
-| `gcp`    | `FORGIT_CHERRY_PICK_GIT_OPTS`     |
-
+| Command  | Option                                                                      |
+| -------- | --------------------------------------------------------------------------- |
+| `ga`     | `FORGIT_ADD_GIT_OPTS`                                                       |
+| `glo`    | `FORGIT_LOG_GIT_OPTS`                                                       |
+| `gd`     | `FORGIT_DIFF_GIT_OPTS`                                                      |
+| `grh`    | `FORGIT_RESET_HEAD_GIT_OPTS`                                                |
+| `gcf`    | `FORGIT_CHECKOUT_FILE_GIT_OPTS`                                             |
+| `gcb`    | `FORGIT_CHECKOUT_BRANCH_GIT_OPTS`, `FORGIT_CHECKOUT_BRANCH_BRANCH_GIT_OPTS` |
+| `gbd`    | `FORGIT_BRANCH_DELETE_GIT_OPTS`                                             |
+| `gct`    | `FORGIT_CHECKOUT_TAG_GIT_OPTS`                                              |
+| `gco`    | `FORGIT_CHECKOUT_COMMIT_GIT_OPTS`                                           |
+| `grc`    | `FORGIT_REVERT_COMMIT_GIT_OPTS`                                             |
+| `gss`    | `FORGIT_STASH_SHOW_GIT_OPTS`                                                |
+| `gsp`    | `FORGIT_STASH_PUSH_GIT_OPTS`                                                |
+| `gclean` | `FORGIT_CLEAN_GIT_OPTS`                                                     |
+| `grb`    | `FORGIT_REBASE_GIT_OPTS`                                                    |
+| `gbl`    | `FORGIT_BLAME_GIT_OPTS`                                                     |
+| `gfu`    | `FORGIT_FIXUP_GIT_OPTS`                                                     |
+| `gcp`    | `FORGIT_CHERRY_PICK_GIT_OPTS`                                               |
 
 #### pagers
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -447,7 +447,7 @@ _forgit_checkout_branch() {
     fi
 
     local git_checkout cmd preview opts branch
-    cmd="git branch --color=always --all | LC_ALL=C sort -k1.1,1.1 -rs"
+    cmd="git branch --color=always ${FORGIT_CHECKOUT_BRANCH_BRANCH_GIT_OPTS:---all} | LC_ALL=C sort -k1.1,1.1 -rs"
     preview="git log {1} $_forgit_log_preview_options"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

Love the project! I'm using it to replace some scripts I'd hand rolled doing roughly the same thing!

However, I was hoping to use `checkout_branch` to quickly swap between recent branches. To do this I'd like to pass `--sort=-committerdate` to the `git branch` command to sort them by most recent commit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
