### PR TITLE
Restore support for appending FORGIT_INSTALL_DIR to path

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -1,9 +1,9 @@
 # MIT (c) Chris Apple
 
 set INSTALL_DIR (dirname (dirname (status -f)))
-set FORGIT "$INSTALL_DIR/conf.d/bin/git-forgit"
+set -x FORGIT "$INSTALL_DIR/conf.d/bin/git-forgit"
 if [ ! -e "$FORGIT" ]
-    set FORGIT "$INSTALL_DIR/vendor_conf.d/bin/git-forgit"
+    set -x FORGIT "$INSTALL_DIR/vendor_conf.d/bin/git-forgit"
 end
 
 function forgit::warn

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -1,9 +1,11 @@
 # MIT (c) Chris Apple
 
 set INSTALL_DIR (dirname (dirname (status -f)))
-set -x FORGIT "$INSTALL_DIR/conf.d/bin/git-forgit"
+set -x FORGIT_INSTALL_DIR "$INSTALL_DIR/conf.d"
+set -x FORGIT "$FORGIT_INSTALL_DIR/bin/git-forgit"
 if [ ! -e "$FORGIT" ]
-    set -x FORGIT "$INSTALL_DIR/vendor_conf.d/bin/git-forgit"
+    set -x FORGIT_INSTALL_DIR "$INSTALL_DIR/vendor_conf.d"
+    set -x FORGIT "$FORGIT_INSTALL_DIR/bin/git-forgit"
 end
 
 function forgit::warn

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -130,6 +130,8 @@ forgit::ignore::clean() {
     "$FORGIT" ignore_clean "$@"
 }
 
+export FORGIT_INSTALL_DIR=$INSTALL_DIR
+
 # register aliases
 # shellcheck disable=SC2139
 if [[ -z "$FORGIT_NO_ALIASES" ]]; then


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

It seems somewhere along the line `FORGIT_INSTALL_DIR` stopped getting exported. According to the README you can append it to your path to get access to `git forgit ...` commands however this seems to no longer work - this is an attempt to restore this functionality.

https://github.com/wfxr/forgit/blob/5642a1a7307c17d452271b9e7aaa8bcec6a47f53/README.md?plain=1#L174

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
