### PR TITLE
Allow passing parameters to forgit::reset::head

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -192,9 +192,9 @@ _forgit_add() {
 # git reset HEAD (unstage) selector
 _forgit_reset_head() {
     _forgit_inside_work_tree || return 1
-    [[ $# -ne 0 ]] && git reset -q "$@" && git status --short && return
     local git_reset_head cmd files opts rootdir
     git_reset_head="git reset -q $FORGIT_RESET_HEAD_GIT_OPTS HEAD"
+    [[ $# -ne 0 ]] && $git_reset_head && git status --short && return
     rootdir=$(git rev-parse --show-toplevel)
     cmd="git diff --staged --color=always -- $rootdir/{} | $_forgit_diff_pager "
     opts="

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -194,7 +194,7 @@ _forgit_reset_head() {
     _forgit_inside_work_tree || return 1
     local git_reset_head cmd files opts rootdir
     git_reset_head="git reset -q $FORGIT_RESET_HEAD_GIT_OPTS HEAD"
-    [[ $# -ne 0 ]] && $git_reset_head && git status --short && return
+    [[ $# -ne 0 ]] && $git_reset_head "$@" && git status --short && return
     rootdir=$(git rev-parse --show-toplevel)
     cmd="git diff --staged --color=always -- $rootdir/{} | $_forgit_diff_pager "
     opts="

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -192,6 +192,7 @@ _forgit_add() {
 # git reset HEAD (unstage) selector
 _forgit_reset_head() {
     _forgit_inside_work_tree || return 1
+    [[ $# -ne 0 ]] && git reset -q "$@" && git status --short && return
     local git_reset_head cmd files opts rootdir
     git_reset_head="git reset -q $FORGIT_RESET_HEAD_GIT_OPTS HEAD"
     rootdir=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Allow passing parameters to forgit::reset::head in the same way we already do for most other functions.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
