### PR TITLE
Allow passing parameters for more functions

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -211,9 +211,11 @@ _forgit_reset_head() {
 # git stash viewer
 _forgit_stash_show() {
     _forgit_inside_work_tree || return 1
-    local git_stash_list cmd opts
+    local git_stash_show git_stash_list cmd opts
+    git_stash_show="git stash show --color=always --ext-diff"
+    [[ $# -ne 0 ]] && $git_stash_show "$@" && return
     git_stash_list="git stash list $FORGIT_STASH_SHOW_GIT_OPTS"
-    cmd="echo {} |cut -d: -f1 |xargs -I% git stash show --color=always --ext-diff % |$_forgit_diff_pager"
+    cmd="echo {} |cut -d: -f1 |xargs -I% $git_stash_show % |$_forgit_diff_pager"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m -0 --tiebreak=index --bind=\"enter:execute($cmd | $_forgit_enter_pager)\"
@@ -516,6 +518,7 @@ _forgit_branch_delete() {
     _forgit_inside_work_tree || return 1
     local git_branch preview opts cmd branches
     git_branch="git branch $FORGIT_BRANCH_DELETE_GIT_OPTS"
+    [[ $# -ne 0 ]] && $git_branch -D "$@" && return
     preview="git log {1} $_forgit_log_preview_options"
 
     opts="


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Noticed that we could also allow passing parameters to forgit::branch::delete and forgit::stash::show. 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
