### PR TITLE
feat: add a keybind to open current file in editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,20 +116,21 @@ Install `forgit` in just one click.
 
 ### ⌨  Keybinds
 
-| Key                                           | Action                    |
-| :-------------------------------------------: | ------------------------- |
-| <kbd>Enter</kbd>                              | Confirm                   |
-| <kbd>Tab</kbd>                                | Toggle mark and move down |
-| <kbd>Shift</kbd> - <kbd>Tab</kbd>             | Toggle mark and move up   |
-| <kbd>?</kbd>                                  | Toggle preview window     |
-| <kbd>Alt</kbd> - <kbd>W</kbd>                 | Toggle preview wrap       |
-| <kbd>Ctrl</kbd> - <kbd>S</kbd>                | Toggle sort               |
-| <kbd>Ctrl</kbd> - <kbd>R</kbd>                | Toggle selection          |
-| <kbd>Ctrl</kbd> - <kbd>Y</kbd>                | Copy commit hash/stash ID*|
-| <kbd>Ctrl</kbd> - <kbd>K</kbd> / <kbd>P</kbd> | Selection move up         |
-| <kbd>Ctrl</kbd> - <kbd>J</kbd> / <kbd>N</kbd> | Selection move down       |
-| <kbd>Alt</kbd> - <kbd>K</kbd> / <kbd>P</kbd>  | Preview move up           |
-| <kbd>Alt</kbd> - <kbd>J</kbd> / <kbd>N</kbd>  | Preview move down         |
+| Key                                           | Action                                      |
+| :-------------------------------------------: | ------------------------------------------- |
+| <kbd>Enter</kbd>                              | Confirm                                     |
+| <kbd>Tab</kbd>                                | Toggle mark and move down                   |
+| <kbd>Shift</kbd> - <kbd>Tab</kbd>             | Toggle mark and move up                     |
+| <kbd>?</kbd>                                  | Toggle preview window                       |
+| <kbd>Alt</kbd> - <kbd>W</kbd>                 | Toggle preview wrap                         |
+| <kbd>Ctrl</kbd> - <kbd>S</kbd>                | Toggle sort                                 |
+| <kbd>Ctrl</kbd> - <kbd>R</kbd>                | Toggle selection                            |
+| <kbd>Ctrl</kbd> - <kbd>Y</kbd>                | Copy commit hash/stash ID*                  |
+| <kbd>Ctrl</kbd> - <kbd>K</kbd> / <kbd>P</kbd> | Selection move up                           |
+| <kbd>Ctrl</kbd> - <kbd>J</kbd> / <kbd>N</kbd> | Selection move down                         |
+| <kbd>Alt</kbd> - <kbd>K</kbd> / <kbd>P</kbd>  | Preview move up                             |
+| <kbd>Alt</kbd> - <kbd>J</kbd> / <kbd>N</kbd>  | Preview move down                           |
+| <kbd>Alt</kbd> - <kbd>E</kbd>                 | Open file in default editor (when possible) |
 
 \* Available when the selection contains a commit hash or a stash ID.
 For linux users `FORGIT_COPY_CMD` should be set to make copy work. Example: `FORGIT_COPY_CMD='xclip -selection clipboard'`.

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -138,7 +138,7 @@ _forgit_diff() {
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"
         --preview=\"$preview_cmd\"
-        --bind=\"alt-e:execute-silent($EDITOR \$\($get_files\) >/dev/tty </dev/tty)\"
+        --bind=\"alt-e:execute-silent($EDITOR \$\($get_files\) >/dev/tty </dev/tty)+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"$commits > \"
     "
@@ -176,7 +176,7 @@ _forgit_add() {
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
         --preview=\"$preview\"
-        --bind=\"alt-e:execute-silent($EDITOR \$\(echo {} | $extract\) >/dev/tty </dev/tty)\"
+        --bind=\"alt-e:execute-silent($EDITOR \$\(echo {} | $extract\) >/dev/tty </dev/tty)+refresh-preview\"
         $FORGIT_ADD_FZF_OPTS
     "
     files=$(git -c color.status=always -c status.relativePaths=true status -su |

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -138,6 +138,7 @@ _forgit_diff() {
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"
         --preview=\"$preview_cmd\"
+        --bind=\"alt-e:execute-silent($EDITOR \$\($get_files\) >/dev/tty </dev/tty)\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"$commits > \"
     "
@@ -163,10 +164,7 @@ _forgit_add() {
     untracked=$(git config --get-color color.status.untracked red)
     # NOTE: paths listed by 'git status -su' mixed with quoted and unquoted style
     # remove indicators | remove original path for rename case | remove surrounding quotes
-    extract="
-        sed 's/^.*]  //' |
-        sed 's/.* -> //' |
-        sed -e 's/^\\\"//' -e 's/\\\"\$//'"
+    extract="sed 's/^.*]  //' | sed 's/.* -> //' | sed -e 's/^\\\"//' -e 's/\\\"\$//'"
     preview="
         file=\$(echo {} | $extract)
         if (git status -s -- \\\"\$file\\\" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
@@ -178,6 +176,7 @@ _forgit_add() {
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
         --preview=\"$preview\"
+        --bind=\"alt-e:execute-silent($EDITOR \$\(echo {} | $extract\) >/dev/tty </dev/tty)\"
         $FORGIT_ADD_FZF_OPTS
     "
     files=$(git -c color.status=always -c status.relativePaths=true status -su |

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -164,7 +164,10 @@ _forgit_add() {
     untracked=$(git config --get-color color.status.untracked red)
     # NOTE: paths listed by 'git status -su' mixed with quoted and unquoted style
     # remove indicators | remove original path for rename case | remove surrounding quotes
-    extract="sed 's/^.*]  //' | sed 's/.* -> //' | sed -e 's/^\\\"//' -e 's/\\\"\$//'"
+    extract="
+        sed 's/^.*]  //' |
+        sed 's/.* -> //' |
+        sed -e 's/^\\\"//' -e 's/\\\"\$//'"
     preview="
         file=\$(echo {} | $extract)
         if (git status -s -- \\\"\$file\\\" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

Add a keybind `alt-e` to allow open current file in default editor. This will facilitate doing diff and modify loop. 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
