### PR TITLE
Added AUR PKGBUILD

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Luis Martinez <luis dot martinez at disroot dot org>
+
+pkgname=forgit
+pkgver=23.03.0
+pkgrel=1
+pkgdesc="Utility tool powered by fzf for using git interactively"
+arch=('any')
+url="https://github.com/wfxr/forgit"
+license=('MIT')
+groups=('fish-plugins' 'zsh-plugins')
+depends=('bash' 'fzf')
+optdepends=(
+	'zsh: supported shell'
+	'fish: supported shell'
+	'git-delta: human readable diffs'
+	'diff-so-fancy: human readable diffs'
+	'bat: syntax highlighting for .gitignore'
+	'emoji-cli: emoji support for git log')
+install="$pkgname.install"
+source=("$pkgname-$pkgver.tar.gz::$url/archive/$pkgver.tar.gz")
+sha256sums=('f64d0a5e0d4064ce9f60825383cca84a5735b3962e6d6c984f13cf8c0b199043')
+
+package() {
+	cd "$pkgname-$pkgver"
+
+	# wrapper script
+	install -Dv bin/git-forgit -t "$pkgdir/usr/bin/"
+
+	# zsh install
+	install -Dvm644 forgit.plugin.zsh -t "$pkgdir/usr/share/zsh/plugins/$pkgname/"
+
+	# fish install
+	install -Dvm644 conf.d/forgit.plugin.fish -t "$pkgdir/usr/share/fish/vendor_conf.d/"
+
+	# docs
+	install -Dvm644 README.md -t "$pkgdir/usr/share/doc/$pkgname/"
+
+	# license
+	install -Dvm644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+}
+


### PR DESCRIPTION
## Check list

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Adding the unchanged (and outdated) PKGBUILD of [aur/forgit](https://aur.archlinux.org/packages/forgit) to the repository. I intentionally decided to add this without any changes, so all changes we make are transparent in the git history. This is the first step towards an automation for publishing new releases to the AUR. We could add the PKGBUILD of [aur/forgit-git](https://aur.archlinux.org/packages/forgit-git) as well, but there wouldn't be anything to automate here, as this is a simple git package that installs from the latest commit of this repository. Does any of you have an opinion on that?
I plan to send in another PR with changes as discussed in #311.


## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
