### PR TITLE
Fix infinite loop when passing invalid arguments to gsp

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -249,7 +249,7 @@ _forgit_stash_push() {
             # ignore -u as it's used implicitly
             -u|--include-untracked) shift ;;
             # pass to git directly when encountering anything else
-            *) $git_stash_push "${args[@]}" && return $?
+            *) $git_stash_push "${args[@]}"; return $?
         esac
     done
     local opts preview files


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Passing invalid arguments to `_forgit_stash_push` results in an infinite loop printing gits error message. You can test this by running `gsp -b`.
With this PR we only print the error message once and return gits exit code.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
