### PR TITLE
Make glcean parameters consistent with other functions

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -274,6 +274,7 @@ _forgit_stash_push() {
 # git clean selector
 _forgit_clean() {
     _forgit_inside_work_tree || return 1
+    [[ $# -ne 0 ]] && git clean "$@" &>/dev/null && return 0
     local git_clean files opts
     git_clean="git clean $FORGIT_CLEAN_GIT_OPTS"
     opts="


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Most functions try to pass parameters directly to git and exit early when successfull. `_forgit_clean` is an exception to this, as it currently only uses the arguments to determine the target files. Our completions use `_git-clean`, which completes untracked files, but `gclean -f FILE` currently opens the file picker.
I've added a line to allow an early out for `_forgit_clean`.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
