### PR TITLE
Meta: Fix AUR action not triggering

### DIFF
--- a/.github/workflows/aur.yaml
+++ b/.github/workflows/aur.yaml
@@ -1,9 +1,11 @@
 name: AUR
 
 on:
-  release:
+  workflow_run:
+    workflows:
+      - "Release"
     types:
-      - "released"
+      - completed
 
 jobs:
   aur:


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Turns out that GitHub actions do not trigger other actions by default. See this [Stack Overflow question](https://stackoverflow.com/questions/69063452/github-actions-on-release-created-workflow-trigger-not-working) for more details. Using `workflow_run` instead of `release` as a trigger should solve this.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
