### PR TITLE
Docs: Removed note about using forgit as a git sub-command from the 'tips' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,6 @@ export FORGIT_LOG_FZF_OPTS='
 - Most of the commands accept optional arguments (eg, `glo develop`, `glo f738479..188a849b -- main.go`, `gco master`).
 - `gd` supports specifying revision(eg, `gd HEAD~`, `gd v1.0 README.md`).
 - Call `gi` with arguments to get the wanted `.gitignore` contents directly(eg, `gi cmake c++`).
-- You can use the commands as sub-commands of `git`, see [#147](https://github.com/wfxr/forgit/issues/147) for details.
 
 ### 📃 License
 


### PR DESCRIPTION
## Description

The note here is redundant because it is explained in more detail in the [git integration](https://github.com/wfxr/forgit#git-integration) section.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [X] Documentation change
