### PR TITLE
checkout_branch: support "-" argument

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -454,7 +454,7 @@ _forgit_checkout_branch() {
     _forgit_inside_work_tree || return 1
     # if called with arguments, check if branch exists, else create a new one
     if [[ $# -ne 0 ]]; then
-        if git show-branch "$@" &>/dev/null; then
+        if [[ "$*" == "-" ]] || git show-branch "$@" &>/dev/null; then
             git switch "$@"
         else
             git switch -c "$@"


### PR DESCRIPTION
git natively supports `-` as an argument to `git switch` and `git checkout`. It is shorthand for `@{-1}`, which is a way to refer to the last branch you were on.

forgit used to interpret `-` as a branch name, detect that it does not exist yet and create a new one with this name, which does not work.

Add a check whether `-` is passed on the command line and do not create a new branch in this case

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
