### PR TITLE
Fix opening files in editor when path contains spaces or file was renamed

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -138,6 +138,9 @@ _forgit_diff() {
     # We have to do a two-step sed -> tr pipe because OSX's sed implementation does
     # not support the null-character directly.
     get_files="echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/' | tr '\\\n' '\\\0'"
+    # Similar to the line above, but only gets a single file from a single line
+    # Gets the new name of renamed files
+    get_file="echo {} | sed 's/.*] *//' | sed 's/.*->  //'"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.
@@ -150,7 +153,7 @@ _forgit_diff() {
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($enter_cmd | $_forgit_enter_pager)\"
         --preview=\"$preview_cmd\"
-        --bind=\"alt-e:execute-silent($EDITOR \$\($get_files\) >/dev/tty </dev/tty)+refresh-preview\"
+        --bind=\"alt-e:execute-silent($EDITOR \\\"\$\($get_file)\\\" >/dev/tty </dev/tty)+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"$commits > \"
     "
@@ -191,7 +194,7 @@ _forgit_add() {
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
         --preview=\"$preview\"
-        --bind=\"alt-e:execute-silent($EDITOR \$\(echo {} | $extract\) >/dev/tty </dev/tty)+refresh-preview\"
+        --bind=\"alt-e:execute-silent($EDITOR \\\"\$\(echo {} | $extract\)\\\" >/dev/tty </dev/tty)+refresh-preview\"
         $FORGIT_ADD_FZF_OPTS
     "
     files=$(git -c color.status=always -c status.relativePaths=true status -su |


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Escaped variables in _forgit_add() and _forgit_diff() to fix opening files that contain spaces.
Added a separate sed command for retrieving a file in _forgit_diff() that correctly handles renamed files (when opening the editor while diffing staged changes).

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
