### PR TITLE
Remove extraneous PATH export

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ You can use forgit as a subcommand of git by making `git-forgit` available in `$
 
 ```sh
 # after `forgit` was loaded
-export PATH="$PATH:$FORGIT_INSTALL_DIR/bin"
+PATH="$PATH:$FORGIT_INSTALL_DIR/bin"
 ```
 
 *Some plugin managers can help do this.*


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

This updates the documentation for using `forgit` as a subcommand of `git` by removing the use of the `export` built-in. For all intensive purposes, `PATH` [is already exported](https://unix.stackexchange.com/a/138557). If it weren't, then executing a subprocess (ex. `system("bash ...")`) would always fail since `PATH` wouldn't be copied from parent to child. This simplifies the export line accordingly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
