### PR TITLE
Fix issues with `ga`, `gsp` & `gcf` with git 2.25.1

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -326,11 +326,14 @@ _forgit_add() {
         --bind=\"alt-e:execute-silent($FORGIT edit_add_file {})+refresh-preview\"
         $FORGIT_ADD_FZF_OPTS
     "
-    read -r -a files <<< "$(git -c color.status=always -c status.relativePaths=true status -su |
+    files=()
+    while IFS='' read -r file; do
+        files+=("$file")
+    done < <(git -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf |
-        _forgit_get_single_file_from_add_line)"
+        _forgit_get_single_file_from_add_line)
     [[ "${#files[@]}" -gt 0 ]] && _forgit_git_add "${files[@]}" && git status -su && return
     echo 'Nothing to add.'
 }
@@ -442,7 +445,11 @@ _forgit_stash_push() {
         $FORGIT_STASH_PUSH_FZF_OPTS
     "
     # Show both modified and untracked files
-    read -r -a files <<< "$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT stash_push_preview {}")"
+    files=()
+    while IFS='' read -r file; do
+        files+=("$file")
+    done < <(git ls-files --exclude-standard --modified --others |
+        FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT stash_push_preview {}")
     [[ "${#files[@]}" -eq 0 ]] && return 1
     _forgit_git_stash_push ${msg:+-m "$msg"} -u "${files[@]}"
 }
@@ -636,7 +643,11 @@ _forgit_checkout_file() {
         --preview=\"$FORGIT checkout_file_preview {}\"
         $FORGIT_CHECKOUT_FILE_FZF_OPTS
     "
-    read -r -a files <<< "$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf)"
+    files=()
+    while IFS='' read -r file; do
+        files+=("$file")
+    done < <(git ls-files --modified "$(git rev-parse --show-toplevel)" |
+        FZF_DEFAULT_OPTS="$opts" fzf)
     [[ "${#files[@]}" -gt 0 ]] && _forgit_git_checkout_file "${files[@]}"
 }
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -326,12 +326,12 @@ _forgit_add() {
         --bind=\"alt-e:execute-silent($FORGIT edit_add_file {})+refresh-preview\"
         $FORGIT_ADD_FZF_OPTS
     "
-    files=$(git -c color.status=always -c status.relativePaths=true status -su |
+    read -r -a files <<< "$(git -c color.status=always -c status.relativePaths=true status -su |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf |
-        _forgit_get_single_file_from_add_line)
-    [[ -n "$files" ]] && echo "$files"| tr '\n' '\0' | _forgit_git_add --pathspec-file-nul --pathspec-from-file - && git status -su && return
+        _forgit_get_single_file_from_add_line)"
+    [[ "${#files[@]}" -gt 0 ]] && _forgit_git_add "${files[@]}" && git status -su && return
     echo 'Nothing to add.'
 }
 
@@ -442,9 +442,9 @@ _forgit_stash_push() {
         $FORGIT_STASH_PUSH_FZF_OPTS
     "
     # Show both modified and untracked files
-    files=$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT stash_push_preview {}")
-    [[ -z "$files" ]] && return 1
-    echo "${files[@]}" | tr '\n' '\0' | _forgit_git_stash_push ${msg:+-m "$msg"} -u --pathspec-file-nul --pathspec-from-file -
+    read -r -a files <<< "$(git ls-files --exclude-standard --modified --others | FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT stash_push_preview {}")"
+    [[ "${#files[@]}" -eq 0 ]] && return 1
+    _forgit_git_stash_push ${msg:+-m "$msg"} -u "${files[@]}"
 }
 
 # git clean selector
@@ -636,8 +636,8 @@ _forgit_checkout_file() {
         --preview=\"$FORGIT checkout_file_preview {}\"
         $FORGIT_CHECKOUT_FILE_FZF_OPTS
     "
-    files="$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf)"
-    [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | _forgit_git_checkout_file --pathspec-file-nul --pathspec-from-file -
+    read -r -a files <<< "$(git ls-files --modified "$(git rev-parse --show-toplevel)"| FZF_DEFAULT_OPTS="$opts" fzf)"
+    [[ "${#files[@]}" -gt 0 ]] && _forgit_git_checkout_file "${files[@]}"
 }
 
 _forgit_git_checkout_branch() {


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

We're currently using `--pathspec-file-nul` in `ga`, `gsp` and `gcf`. This option is not available in older versions of git, such as the current release in the Ubuntu repositories (2.25.1). This PR removes the usage of `--pathspec-file-nul` in favor of storing the file names passed to the git command in an array instead of a string.  
This PR is based on #326. I will rebase and mark it as ready for review, once #326 is merged.

Fixes #328

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
