### PR TITLE
Add new workflow to update homebrew formula on release

### DIFF
--- a/.github/workflows/brew.yaml
+++ b/.github/workflows/brew.yaml
@@ -1,4 +1,4 @@
-name: brew
+name: Homebrew
 
 on:
   workflow_run:
@@ -8,7 +8,7 @@ on:
       - completed
 
 jobs:
-  aur:
+  brew:
     runs-on: ubuntu-latest
     steps:
       - name: Update Homebrew formula

--- a/.github/workflows/brew.yaml
+++ b/.github/workflows/brew.yaml
@@ -1,4 +1,4 @@
-name: Homebrew
+name: brew
 
 on:
   workflow_run:
@@ -15,6 +15,6 @@ jobs:
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes
-          token: ${{secrets.TOKEN}}
+          token: ${{secrets.BREW_TOKEN}}
           # Formula name, required
           formula: forgit

--- a/.github/workflows/brew.yaml
+++ b/.github/workflows/brew.yaml
@@ -1,0 +1,20 @@
+name: Homebrew
+
+on:
+  workflow_run:
+    workflows:
+      - "Release"
+    types:
+      - completed
+
+jobs:
+  aur:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes
+          token: ${{secrets.TOKEN}}
+          # Formula name, required
+          formula: forgit


### PR DESCRIPTION
This workflow was found here:

https://github.com/dawidd6/action-homebrew-bump-formula

This should be very similar to our AUR workflow, which can be seen here:
https://github.com/wfxr/forgit/blob/ab7400ddb37c758b8247ce0884cd2283a873e258/.github/workflows/aur.yaml#L1-L20


I am writing an email to @wfxr asking him to add a BREW_TOKEN to our secrets with the appropriate permissions so this can run :). This change should not be submitted until he has confirmed the BREW_TOKEN has been added to our secrets.