### PR TITLE
Add new workflow to update homebrew formula on release 

### DIFF
--- a/.github/workflows/brew.yaml
+++ b/.github/workflows/brew.yaml
@@ -1,0 +1,20 @@
+name: Homebrew
+
+on:
+  workflow_run:
+    workflows:
+      - "Release"
+    types:
+      - completed
+
+jobs:
+  brew:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          # Required, custom GitHub access token with the 'public_repo' and 'workflow' scopes
+          token: ${{secrets.BREW_TOKEN}}
+          # Formula name, required
+          formula: forgit


### PR DESCRIPTION
This is a rehash of #341 but with the correct base.

This workflow was found here:

https://github.com/dawidd6/action-homebrew-bump-formula

This should be very similar to our AUR workflow, which can be seen here:

[forgit/.github/workflows/aur.yaml](https://github.com/wfxr/forgit/blob/ab7400ddb37c758b8247ce0884cd2283a873e258/.github/workflows/aur.yaml#L1-L20)

Lines 1 to 20 in [ab7400d](https://github.com/wfxr/forgit/commit/ab7400ddb37c758b8247ce0884cd2283a873e258)
 name: AUR 
  
 on: 
   workflow_run: 
     workflows: 
       - "Release" 
     types: 
       - completed 
  
 jobs: 
   aur: 
     runs-on: ubuntu-latest 
     steps: 
       - name: Publish 
         uses: zokugun/github-actions-aur-releaser@v1 
         with: 
           package_name: forgit 
           aur_private_key: ${{ secrets.AUR_PRIVATE_KEY }} 
           aur_username: ${{ secrets.AUR_USERNAME }} 
           aur_email: ${{ secrets.AUR_EMAIL }} 

