### PR TITLE
feat(completions): add completion for fish

### DIFF
--- a/completions/git-forgit.fish
+++ b/completions/git-forgit.fish
@@ -1,0 +1,59 @@
+#
+# forgit completions for fish plugin
+#
+# Place this file inside your <fish_config_dir>/completions/ directory.
+# It's usually located at ~/.config/fish/completions/. The file is lazily
+# sourced when git-forgit command or forgit subcommand of git is invoked.
+
+function __fish_forgit_needs_subcommand
+    for subcmd in add blame branch_delete checkout_branch checkout_commit checkout_file checkout_tag \
+        cherry_pick cherry_pick_from_branch clean diff fixup ignore log rebase reset_head revert_commit \
+        stash_show stash_push
+        if contains -- $subcmd (commandline -opc)
+            return 1
+        end
+    end
+    return 0
+end
+
+# Load helper functions in git completion file
+not functions -q __fish_git && source $__fish_data_dir/completions/git.fish
+
+# No file completion by default
+complete -c git-forgit -x
+
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a add -d 'git add selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a blame -d 'git blame viewer'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a branch_delete -d 'git branch deletion selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a checkout_branch -d 'git checkout branch selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a checkout_commit -d 'git checkout commit selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a checkout_file -d 'git checkout-file selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a checkout_tag -d 'git checkout tag selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a cherry_pick -d 'git cherry-picking'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a cherry_pick_from_branch -d 'git cherry-picking with interactive branch selection'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a clean -d 'git clean selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a diff -d 'git diff viewer'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a fixup -d 'git fixup'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a ignore -d 'git ignore generator'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a log -d 'git commit viewer'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a rebase -d 'git rebase'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a reset_head -d 'git reset HEAD (unstage) selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a revert_commit -d 'git revert commit selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a stash_show -d 'git stash viewer'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a stash_push -d 'git stash push selector'
+
+complete -c git-forgit -n '__fish_seen_subcommand_from add' -a "(complete -C 'git add ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from branch_delete' -a "(__fish_git_local_branches)"
+complete -c git-forgit -n '__fish_seen_subcommand_from checkout_branch' -a "(complete -C 'git switch ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from checkout_commit' -a "(__fish_git_commits)"
+complete -c git-forgit -n '__fish_seen_subcommand_from checkout_file' -a "(__fish_git_files modified)"
+complete -c git-forgit -n '__fish_seen_subcommand_from checkout_tag' -a "(__fish_git_tags)" -d Tag
+complete -c git-forgit -n '__fish_seen_subcommand_from cherry_pick' -a "(complete -C 'git cherry-pick ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from clean' -a "(__fish_git_files untracked ignored)"
+complete -c git-forgit -n '__fish_seen_subcommand_from fixup' -a "(__fish_git_local_branches)"
+complete -c git-forgit -n '__fish_seen_subcommand_from log' -a "(complete -C 'git log ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from rebase' -a "(complete -C 'git rebase ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from reset_head' -a "(__fish_git_files all-staged)"
+complete -c git-forgit -n '__fish_seen_subcommand_from revert_commit' -a "(__fish_git_commits)"
+complete -c git-forgit -n '__fish_seen_subcommand_from stash_show' -a "(__fish_git_complete_stashes)"
+complete -c git-forgit -n '__fish_seen_subcommand_from stash_push' -a "(__fish_git_files modified deleted modified-staged-deleted)"


### PR DESCRIPTION
fish's builtin git completion automatically registers `git-forgit` completions as completions for `forgit` subcommand of git. Therefore this PR provides completions for both formats `git-forgit` and `git forgit`.

Simple subcommands get the completion list from `__fish_git_*` functions, while others requiring more than 1 `__fish_git_*` completion sources reuse the completion items from the corresponding git commands.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
