### PR TITLE
Auto enable completion

### DIFF
--- a/completions/git-forgit.bash
+++ b/completions/git-forgit.bash
@@ -6,9 +6,6 @@
 #
 #   /usr/share/bash-completion/completions
 #   ~/.local/share/bash-completion/completions
-#
-# When using forgit via the shell plugin, source this file explicitly after
-# forgit.plugin.zsh to enable tab completion for shell functions and aliases.
 
 _git_branch_delete()
 {

--- a/completions/git-forgit.bash
+++ b/completions/git-forgit.bash
@@ -6,6 +6,9 @@
 #
 #   /usr/share/bash-completion/completions
 #   ~/.local/share/bash-completion/completions
+#
+# When using forgit via the shell plugin, source this file explicitly after
+# forgit.plugin.zsh to enable tab completion for shell functions and aliases.
 
 _git_branch_delete()
 {

--- a/completions/git-forgit.zsh
+++ b/completions/git-forgit.zsh
@@ -1,10 +1,5 @@
 #!/bin/zsh
-#
 # forgit completions for zsh plugin
-#
-# When using forgit via the shell plugin, place completions/_git-forgit in your
-# $fpath (e.g. /usr/share/zsh/site-functions) and source this file after
-# forgit.plugin.zsh to enable tab completion for shell functions and aliases.
 
 # Check if forgit plugin is loaded
 if (( $+functions[forgit::add] )); then

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -11,6 +11,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
     # shellcheck disable=2277,2296,2298
     0="${${(M)0:#/*}:-$PWD/$0}"
     INSTALL_DIR="${0:h}"
+    # shellcheck disable=SC2206
     fpath=("$INSTALL_DIR/completions" $fpath)
 elif [[ -n "$BASH_VERSION" ]]; then
     INSTALL_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
@@ -178,7 +179,9 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
 fi
 
 if [[ -n "$ZSH_VERSION" ]]; then
+    # shellcheck source=/dev/null
     source "$INSTALL_DIR/completions/git-forgit.zsh"
 elif [[ -n "$BASH_VERSION" ]]; then
+    # shellcheck source=/dev/null
     source "$INSTALL_DIR/completions/git-forgit.bash"
 fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -179,4 +179,6 @@ fi
 
 if [[ -n "$ZSH_VERSION" ]]; then
     source "$INSTALL_DIR/completions/git-forgit.zsh"
+elif [[ -n "$BASH_VERSION" ]]; then
+    source "$INSTALL_DIR/completions/git-forgit.bash"
 fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -181,7 +181,4 @@ fi
 if [[ -n "$ZSH_VERSION" ]]; then
     # shellcheck source=/dev/null
     source "$INSTALL_DIR/completions/git-forgit.zsh"
-elif [[ -n "$BASH_VERSION" ]]; then
-    # shellcheck source=/dev/null
-    source "$INSTALL_DIR/completions/git-forgit.bash"
 fi

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -11,6 +11,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
     # shellcheck disable=2277,2296,2298
     0="${${(M)0:#/*}:-$PWD/$0}"
     INSTALL_DIR="${0:h}"
+    fpath=("$INSTALL_DIR/completions" $fpath)
 elif [[ -n "$BASH_VERSION" ]]; then
     INSTALL_DIR="$(dirname -- "${BASH_SOURCE[0]}")"
 else
@@ -174,4 +175,8 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_fixup}"='forgit::fixup'
     alias "${forgit_blame}"='forgit::blame'
 
+fi
+
+if [[ -n "$ZSH_VERSION" ]]; then
+    source "$INSTALL_DIR/completions/git-forgit.zsh"
 fi


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

We can enable completions automatically for `zsh` ~~and `bash`~~.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
