### PR TITLE
feat(fish): use abbr instead of alias

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -27,206 +27,27 @@ set | awk -F ' ' '{ print $1 }' | grep FORGIT_ | while read var
     end
 end
 
-function forgit::log -d "git commit viewer"
-    "$FORGIT" log $argv
-end
+# alias `git-forgit` to the full-path of the command
+alias git-forgit "$FORGIT_INSTALL_DIR/bin/git-forgit"
 
-function forgit::diff -d "git diff viewer" --argument-names arg1 arg2
-    "$FORGIT" diff $argv
-end
-
-function forgit::add -d "git add selector" --wraps "git add"
-    "$FORGIT" add $argv
-end
-
-function forgit::reset::head -d "git reset HEAD (unstage) selector"
-    "$FORGIT" reset_head $argv
-end
-
-function forgit::stash::show -d "git stash viewer"
-    "$FORGIT" stash_show $argv
-end
-
-function forgit::stash::push -d "git stash push selector" ()
-    "$FORGIT" stash_push $argv
-end
-
-function forgit::clean -d "git clean selector"
-    "$FORGIT" clean $argv
-end
-
-function forgit::cherry::pick -d "git cherry-picking" --argument-names 'target' --wraps "git cherry-pick"
-    "$FORGIT" cherry_pick $argv
-end
-
-function forgit::cherry::pick::from::branch -d "git cherry-picking with interactive branch selection" --wraps "git cherry-pick"
-    "$FORGIT" cherry_pick_from_branch $argv
-end
-
-function forgit::rebase -d "git rebase"
-    "$FORGIT" rebase $argv
-end
-
-function forgit::fixup -d "git fixup"
-    "$FORGIT" fixup $argv
-end
-
-function forgit::checkout::file -d "git checkout-file selector" --argument-names 'file_name' --wraps "git checkout --"
-    "$FORGIT" checkout_file $argv
-end
-
-function forgit::checkout::branch -d "git checkout branch selector" --argument-names 'input_branch_name' --wraps "git branch"
-    "$FORGIT" checkout_branch $argv
-end
-
-function forgit::checkout::tag -d "git checkout tag selector" --argument-names 'tag_name' --wraps "git checkout"
-    "$FORGIT" checkout_tag $argv
-end
-
-function forgit::checkout::commit -d "git checkout commit selector" --argument-names 'commit_id' --wraps "git checkout"
-    "$FORGIT" checkout_commit $argv
-end
-
-function forgit::branch::delete -d "git branch deletion selector" --wraps "git branch --delete"
-    "$FORGIT" branch_delete $argv
-end
-
-function forgit::revert::commit -d "git revert commit selector" --argument-names 'commit_hash' --wraps "git revert --"
-    "$FORGIT" revert_commit $argv
-end
-
-function forgit::blame -d "git blame viewer"
-    "$FORGIT" blame $argv
-end
-
-function forgit::ignore -d "git ignore generator"
-    "$FORGIT" ignore $argv
-end
-
-function forgit::ignore::update
-    "$FORGIT" ignore_update $argv
-end
-
-function forgit::ignore::get
-    "$FORGIT" ignore_get $argv
-end
-
-function forgit::ignore::list
-    "$FORGIT" ignore_list $argv
-end
-
-function forgit::ignore::clean
-    "$FORGIT" ignore_clean $argv
-end
-
-# register aliases
+# register abbreviations
 if test -z "$FORGIT_NO_ALIASES"
-    if test -n "$forgit_add"
-        alias $forgit_add 'forgit::add'
-    else
-        alias ga 'forgit::add'
-    end
-
-    if test -n "$forgit_reset_head"
-        alias $forgit_reset_head 'forgit::reset::head'
-    else
-        alias grh 'forgit::reset::head'
-    end
-
-    if test -n "$forgit_log"
-        alias $forgit_log 'forgit::log'
-    else
-        alias glo 'forgit::log'
-    end
-
-    if test -n "$forgit_diff"
-        alias $forgit_diff 'forgit::diff'
-    else
-        alias gd 'forgit::diff'
-    end
-
-    if test -n "$forgit_ignore"
-        alias $forgit_ignore 'forgit::ignore'
-    else
-        alias gi 'forgit::ignore'
-    end
-
-    if test -n "$forgit_checkout_file"
-        alias $forgit_checkout_file 'forgit::checkout::file'
-    else
-        alias gcf 'forgit::checkout::file'
-    end
-
-    if test -n "$forgit_checkout_branch"
-        alias $forgit_checkout_branch 'forgit::checkout::branch'
-    else
-        alias gcb 'forgit::checkout::branch'
-    end
-
-    if test -n "$forgit_branch_delete"
-        alias $forgit_branch_delete 'forgit::branch::delete'
-    else
-        alias gbd 'forgit::branch::delete'
-    end
-
-    if test -n "$forgit_clean"
-        alias $forgit_clean 'forgit::clean'
-    else
-        alias gclean 'forgit::clean'
-    end
-
-    if test -n "$forgit_stash_show"
-        alias $forgit_stash_show 'forgit::stash::show'
-    else
-        alias gss 'forgit::stash::show'
-    end
-
-    if test -n "$forgit_stash_push"
-        alias $forgit_stash_push 'forgit::stash::push'
-    else
-        alias gsp 'forgit::stash::push'
-    end
-
-    if test -n "$forgit_cherry_pick"
-        alias $forgit_cherry_pick 'forgit::cherry::pick::from::branch'
-    else
-        alias gcp 'forgit::cherry::pick::from::branch'
-    end
-
-    if test -n "$forgit_rebase"
-        alias $forgit_rebase 'forgit::rebase'
-    else
-        alias grb 'forgit::rebase'
-    end
-
-    if test -n "$forgit_fixup"
-        alias $forgit_fixup 'forgit::fixup'
-    else
-        alias gfu 'forgit::fixup'
-    end
-
-    if test -n "$forgit_checkout_commit"
-        alias $forgit_checkout_commit 'forgit::checkout::commit'
-    else
-        alias gco 'forgit::checkout::commit'
-    end
-
-    if test -n "$forgit_revert_commit"
-        alias $forgit_revert_commit 'forgit::revert::commit'
-    else
-        alias grc 'forgit::revert::commit'
-    end
-
-    if test -n "$forgit_blame"
-        alias $forgit_blame 'forgit::blame'
-    else
-        alias gbl 'forgit::blame'
-    end
-
-    if test -n "$forgit_checkout_tag"
-        alias $forgit_checkout_tag 'forgit::checkout::tag'
-    else
-        alias gct 'forgit::checkout::tag'
-    end
-
+    abbr -a -- (string collect $forgit_add; or string collect "ga") git-forgit add
+    abbr -a -- (string collect $forgit_reset_head; or string collect "grh") git-forgit reset_head
+    abbr -a -- (string collect $forgit_log; or string collect "glo") git-forgit log
+    abbr -a -- (string collect $forgit_diff; or string collect "gd") git-forgit diff
+    abbr -a -- (string collect $forgit_ignore; or string collect "gi") git-forgit ignore
+    abbr -a -- (string collect $forgit_checkout_file; or string collect "gcf") git-forgit checkout_file
+    abbr -a -- (string collect $forgit_checkout_branch; or string collect "gcb") git-forgit checkout_branch
+    abbr -a -- (string collect $forgit_branch_delete; or string collect "gbd") git-forgit branch_delete
+    abbr -a -- (string collect $forgit_clean; or string collect "gclean") git-forgit clean
+    abbr -a -- (string collect $forgit_stash_show; or string collect "gss") git-forgit stash_show
+    abbr -a -- (string collect $forgit_stash_push; or string collect "gsp") git-forgit stash_push
+    abbr -a -- (string collect $forgit_cherry_pick; or string collect "gcp") git-forgit cherry_pick_from_branch
+    abbr -a -- (string collect $forgit_rebase; or string collect "grb") git-forgit rebase
+    abbr -a -- (string collect $forgit_fixup; or string collect "gfu") git-forgit fixup
+    abbr -a -- (string collect $forgit_checkout_commit; or string collect "gco") git-forgit checkout_commit
+    abbr -a -- (string collect $forgit_revert_commit; or string collect "grc") git-forgit revert_commit
+    abbr -a -- (string collect $forgit_blame; or string collect "gbl") git-forgit blame
+    abbr -a -- (string collect $forgit_checkout_tag; or string collect "gct") git-forgit checkout_tag
 end


### PR DESCRIPTION
<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

* Switch from aliases to abbreviations, as I suggested in https://github.com/wfxr/forgit/pull/344#issuecomment-1930072329
* `string collect` returns 1 on empty argument, so it's used here to avoid repeating `if else end` blocks. Another benefit is that the output of `string collect` is ensured to be a single string. From `string --help`:
> `string collect` collects its input into a single output argument, without splitting the output when used in a command substitution. This is useful when trying to collect multiline output from another
command into a variable. Exit status: 0 if any output argument is non-empty, or 1 otherwise.

This PR is marked as breaking change, since abbr behaves differently from alias. It can only be used in the interactive command line (so putting `exec glo` into your scripts won't work).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
