### PR TITLE
fix(fish): clean up variables

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -1,10 +1,10 @@
 # MIT (c) Chris Apple
 
-set INSTALL_DIR (dirname (dirname (status -f)))
-set -x FORGIT_INSTALL_DIR "$INSTALL_DIR/conf.d"
+set -l install_dir (dirname (status dirname))
+set -x FORGIT_INSTALL_DIR "$install_dir/conf.d"
 set -x FORGIT "$FORGIT_INSTALL_DIR/bin/git-forgit"
-if [ ! -e "$FORGIT" ]
-    set -x FORGIT_INSTALL_DIR "$INSTALL_DIR/vendor_conf.d"
+if not test -e "$FORGIT"
+    set -x FORGIT_INSTALL_DIR "$install_dir/vendor_conf.d"
     set -x FORGIT "$FORGIT_INSTALL_DIR/bin/git-forgit"
 end
 


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

* use `status dirname` builtin to save 1 dirname call
* use builtin `test` function instead of `[` syntax
* use local scoping for INSTALL_DIR variable (and make it lowercase to indicate such change)

Ref: https://fishshell.com/docs/current/cmds/test.html

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
