### PR TITLE
Fix diff preview and edit for files with a ']' character in their name

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -137,10 +137,10 @@ _forgit_diff() {
     #   oldfile\0
     # We have to do a two-step sed -> tr pipe because OSX's sed implementation does
     # not support the null-character directly.
-    get_files="echo {} | sed 's/.*] *//' | sed 's/  ->  /\\\n/' | tr '\\\n' '\\\0'"
+    get_files="echo {} | sed 's/\\\\s*\\\\[.]\\\\s*//' | sed 's/  ->  /\\\n/' | tr '\\\n' '\\\0'"
     # Similar to the line above, but only gets a single file from a single line
     # Gets the new name of renamed files
-    get_file="echo {} | sed 's/.*] *//' | sed 's/.*->  //'"
+    get_file="echo {} | sed 's/\\\\s*\\\\[.]\\\\s*//' | sed 's/.*->  //'"
     # Git stashes are named "stash@{x}", which contains the fzf placeholder "{x}".
     # In order to support passing stashes as arguments to _forgit_diff, we have to
     # prevent fzf from interpreting this substring by escaping the opening bracket.


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Our sed command for removing the short status (e.g. [M]) from gits
output to extract the file name with \_forgit\_diff matched until the
last ']' character in the line due to sed being greedy. This created
issues with file names that contain a ']' character.
To fix this, I made sure that only the short status is removed by sed,
independently of the file name.
Fixes #353

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
