### PR TITLE
Fix homebrew update action to run on tag push

### DIFF
--- a/.github/workflows/brew.yaml
+++ b/.github/workflows/brew.yaml
@@ -1,11 +1,9 @@
 name: Homebrew
 
 on:
-  workflow_run:
-    workflows:
-      - "Release"
-    types:
-      - completed
+  push:
+    tags:
+      - '*'
 
 jobs:
   brew:


### PR DESCRIPTION
The first time the homebrew auto update ran, it failed:

https://github.com/wfxr/forgit/actions/runs/8104493571/job/22151209325

The readme of our package we are using:
https://github.com/dawidd6/action-homebrew-bump-formula?tab=readme-ov-file

May rely on the tag push to extract some information, so I modified it to match their recommendation.