### PR TITLE
Refactor: Quote variables in preview of _forgit_diff, _forgit_reset_head & _forgit_cherry_pick_form_branch

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -263,7 +263,7 @@ _forgit_diff() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $_forgit_enter_pager)\"
-        --preview=\"$FORGIT diff_view {} $_forgit_preview_context $escaped_commits\"
+        --preview=\"$FORGIT diff_view {} \"$_forgit_preview_context\" $escaped_commits\"
         --bind=\"alt-e:execute-silent($FORGIT edit_diffed_file {})+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"${commits[*]} > \"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -263,7 +263,7 @@ _forgit_diff() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $_forgit_enter_pager)\"
-        --preview='$FORGIT diff_view {} \"$_forgit_preview_context\" $escaped_commits'
+        --preview=\"$FORGIT diff_view {} '$_forgit_preview_context' $escaped_commits\"
         --bind=\"alt-e:execute-silent($FORGIT edit_diffed_file {})+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"${commits[*]} > \"
@@ -355,7 +355,7 @@ _forgit_reset_head() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
-        --preview='$FORGIT reset_head_preview \"$rootdir\"/{}'
+        --preview=\"$FORGIT reset_head_preview '$rootdir'/{}\"
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
     files=()
@@ -527,7 +527,7 @@ _forgit_cherry_pick_from_branch() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index --header-lines=1
-        --preview='$FORGIT cherry_pick_from_branch_preview \"$base\" {1}'
+        --preview=\"$FORGIT cherry_pick_from_branch_preview '$base' {1}\"
         $FORGIT_CHERRY_PICK_FROM_BRANCH_FZF_OPTS
         "
     # loop until either the branch selector is closed or a commit to be cherry

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -263,7 +263,7 @@ _forgit_diff() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $_forgit_enter_pager)\"
-        --preview=\"$FORGIT diff_view {} \"$_forgit_preview_context\" $escaped_commits\"
+        --preview='$FORGIT diff_view {} \"$_forgit_preview_context\" $escaped_commits'
         --bind=\"alt-e:execute-silent($FORGIT edit_diffed_file {})+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"${commits[*]} > \"
@@ -355,7 +355,7 @@ _forgit_reset_head() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
-        --preview=\"$FORGIT reset_head_preview \"$rootdir\"/{}\"
+        --preview='$FORGIT reset_head_preview \"$rootdir\"/{}'
         $FORGIT_RESET_HEAD_FZF_OPTS
     "
     files=()
@@ -527,7 +527,7 @@ _forgit_cherry_pick_from_branch() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index --header-lines=1
-        --preview=\"$FORGIT cherry_pick_from_branch_preview \"$base\" {1}\"
+        --preview='$FORGIT cherry_pick_from_branch_preview \"$base\" {1}'
         $FORGIT_CHERRY_PICK_FROM_BRANCH_FZF_OPTS
         "
     # loop until either the branch selector is closed or a commit to be cherry


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

The `$_forgit_preview_context` variable used in the deferred code block for generating the preview of `_forgit_diff` was not quoted. No known bugs were caused by this, just making sure we follow best practices.

## Note

This is a follow-up to #326 and was originally discussed [here](https://github.com/wfxr/forgit/pull/326#discussion_r1527607723).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
