### PR TITLE
Fix branch preview for branches that have the same name as a file

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -740,7 +740,9 @@ _forgit_checkout_commit() {
 }
 
 _forgit_branch_preview() {
-    git log "$1" "${_forgit_log_preview_options[@]}"
+    # the trailing '--' ensures that this works for branches that have a name
+    # that is identical to a file
+    git log "$1" "${_forgit_log_preview_options[@]}" --
 }
 
 _forgit_git_branch_delete() {


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

The preview for branches (when using `gbd` or `gcb`) did not work for branches that have the same name as a file in the repository.
The preview creates the following error message when adding a branch called 'LICENSE' to this repository and trying to preview it:

```
fatal: ambiguous argument 'LICENSE': both revision and filename                                                                                     

Use '--' to separate paths from revisions, like this:                                                                                               

'git <command> [<revision>...] -- [<file>...]'
```

This PR fixes this behavior by separating files and revisions with '--' as git suggests, while leaving the files blank to keep matching all files.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
