### PR TITLE
Fix _forgit_diff on macOS

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -242,6 +242,8 @@ _forgit_diff_enter() {
 _forgit_diff() {
     _forgit_inside_work_tree || return 1
     local files opts commits escaped_commits
+    commits=()
+    files=()
     [[ $# -ne 0 ]] && {
         if git rev-parse "$1" -- &>/dev/null ; then
             if [[ $# -gt 1 ]] && git rev-parse "$2" -- &>/dev/null; then


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

In bash 3.2 uninitialized arrays contain one entry: an empty string, whereas in modern versions of bash they do not contain any entry. I could not find documentation on this but the behavior can be verified by running the following script:

```sh
local arr
echo "length=${#arr[@]}"
echo "content=${arr[@]}"
```

On bash 5.2.26 this prints

```
length=0
content=
```

On bash 3.2.57 this prints
```
length=1
content=
```

This PR makes sure the `$commits` and `$files` arrays are explicitly initialized as empty arrays to allow git to fall back to diffing local changes instead of trying to diff against a revision with a name of an empty string.

Fixes #373

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
