### PR TITLE
Fix: Early out from _forgit_stash_push when no files can be stashed

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -467,8 +467,8 @@ _forgit_stash_push() {
     while IFS='' read -r file; do
         files+=("$file")
     done < <(git ls-files --exclude-standard --modified --others |
-        FZF_DEFAULT_OPTS="$opts" fzf)
-    [[ "${#files[@]}" -eq 0 ]] && return 1
+        FZF_DEFAULT_OPTS="$opts" fzf --exit-0)
+    [[ "${#files[@]}" -eq 0 ]] && echo "Nothing to stash" && return 1
     _forgit_git_stash_push ${msg:+-m "$msg"} -u "${files[@]}"
 }
 


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Previously when using gsp without any local changes, an empty file picker would open. Check if any files can be stashed and show a message instead when this isn't the case.
Fixes #369

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
