### PR TITLE
Refactor: Do not ignore shellcheck 2207

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -499,11 +499,10 @@ _forgit_cherry_pick() {
     [[ $fzf_exitval != 0 ]] && return $fzf_exitval
     [[ -z "$fzf_selection" ]] && return $fzf_exitval
 
-    ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
-    IFS=$'\n'
-    # shellcheck disable=2207
-    commits=($(echo "$fzf_selection" | sort -n -k 1 | cut -f2 | cut -d' ' -f1 | _forgit_reverse_lines))
-    ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
+    commits=()
+    while IFS='' read -r commit; do
+        commits+=("$commit")
+    done < <(echo "$fzf_selection" | sort -n -k 1 | cut -f2 | cut -d' ' -f1 | _forgit_reverse_lines)
     [ ${#commits[@]} -eq 0 ] && return 1
     
     _forgit_cherry_pick_git_opts=()
@@ -804,18 +803,17 @@ _forgit_revert_commit() {
     # The instances of "cut", "nl" and "sort" all serve this purpose
     # Please see https://github.com/wfxr/forgit/issues/253 for more details
 
-    ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
-    IFS=$'\n'
-    # shellcheck disable=2207
-    commits=($(
+    commits=()
+    while IFS='' read -r commit; do
+        commits+=("$commit")
+    done < <(
         git log --graph --color=always --format="$_forgit_log_format" |
         _forgit_emojify |
         nl |
         FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT revert_preview {}" -m |
         sort -n -k 1 | 
         cut -f2- |
-        sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/'))
-    ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
+        sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/')
 
     [ ${#commits[@]} -eq 0 ] && return 1
 
@@ -847,11 +845,10 @@ _forgit_blame() {
         $FORGIT_FZF_DEFAULT_OPTS
         $FORGIT_BLAME_FZF_OPTS
     "
-    ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
-    IFS=$'\n'
-    #shellcheck disable=2207
-    flags=($(git rev-parse --flags "$@"))
-    ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
+    flags=()
+    while IFS='' read -r flag; do
+        flags+=("$flag")
+    done < <(git rev-parse --flags "$@")
     # flags is not quoted here, which is fine given that they are retrieved
     # with git rev-parse and can only contain flags
     file=$(FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT blame_preview {} ${flags[*]}")
@@ -877,12 +874,14 @@ _forgit_ignore() {
         --preview=\"$FORGIT ignore_preview {2}\"
         $FORGIT_IGNORE_FZF_OPTS
     "
-    ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
-    IFS=$'\n'
-    # shellcheck disable=SC2206,2207
-    args=($@) && [[ $# -eq 0 ]] && args=($(_forgit_ignore_list | nl -w4 -s'  ' |
-        FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}'))
-    ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
+    # shellcheck disable=SC2206
+    args=($@) && [[ $# -eq 0 ]] && {
+        args=()
+        while IFS='' read -r arg; do
+            args+=("$arg")
+        done < <(_forgit_ignore_list | nl -w4 -s'  ' |
+            FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}')
+    }
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     _forgit_ignore_get ${args[@]}

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -875,13 +875,14 @@ _forgit_ignore() {
         $FORGIT_IGNORE_FZF_OPTS
     "
     # shellcheck disable=SC2206
-    args=($@) && [[ $# -eq 0 ]] && {
+    args=($@)
+    if [[ $# -eq 0 ]]; then
         args=()
         while IFS='' read -r arg; do
             args+=("$arg")
         done < <(_forgit_ignore_list | nl -w4 -s'  ' |
             FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}')
-    }
+    fi
     [ ${#args[@]} -eq 0 ] && return 1
     # shellcheck disable=SC2068
     _forgit_ignore_get ${args[@]}


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

We sometimes capture multiline output in an array. We used to do so directly, while setting IFS to "\n" to control splitting. This has the downside that bashs glob expansion will be invoked.
I think the original reason we did use this technique was that it does work in both zsh and bash. Since we always execute bin/git-forgit in bash now, this is not necessary anymore. We can use `read -r` in such cases to add each line to the array without glob expansion. This is the idiomatic way to do so and recommended in [shellcheck 2207](https://www.shellcheck.net/wiki/SC2207). In my personal opinion this is also a cleaner and more straightforward approach than setting and resetting `$IFS`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
