### PR TITLE
Fix bug where homebrew replacement wouldn't work

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -28,7 +28,7 @@ set | awk -F ' ' '{ print $1 }' | grep FORGIT_ | while read var
 end
 
 # alias `git-forgit` to the full-path of the command
-alias git-forgit "$FORGIT_INSTALL_DIR/bin/git-forgit"
+alias git-forgit "$FORGIT"
 
 # register abbreviations
 if test -z "$FORGIT_NO_ALIASES"


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

In our homebrew formula, we were replacing this line in the installation:

```
 Replace this:             'set -x FORGIT "$FORGIT_INSTALL_DIR/bin/git-forgit"',
  with this     :             "set -x FORGIT \"#{opt_prefix}/bin/git-forgit\""
```

However, later in the fish script, we ignored that, just basing it directly off of the install dir:

```
alias git-forgit "$FORGIT_INSTALL_DIR/bin/git-forgit"
```

This makes sure that we always line up and don't have `fish: Unknown command: /opt/homebrew/share/conf.d/bin/git-forgit
- (line 1):` as in #377 


Fixes #377 

## Type of change

- [x] Bug fix

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:
