### PR TITLE
Fix: Pager variables are not evaluated

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -127,12 +127,53 @@ _forgit_quote_files() {
     echo "${files[*]}"
 }
 
-_forgit_pager=${FORGIT_PAGER:-$(git config core.pager || echo 'cat')}
-_forgit_show_pager=${FORGIT_SHOW_PAGER:-$(git config pager.show || echo "$_forgit_pager")}
-_forgit_diff_pager=${FORGIT_DIFF_PAGER:-$(git config pager.diff || echo "$_forgit_pager")}
-_forgit_ignore_pager=${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -l gitignore --color=always' || echo 'cat')}
-_forgit_blame_pager=${FORGIT_BLAME_PAGER:-$(git config pager.blame || echo "$_forgit_pager")}
-_forgit_enter_pager=${FORGIT_ENTER_PAGER:-"LESS='-r' less"}
+_forgit_page() {
+    local pager
+    pager=${FORGIT_PAGER:-$(git config core.pager)}
+    if [[ -n $pager ]]; then
+        eval "$pager"
+    else
+        cat
+    fi
+}
+
+_forgit_diff_page() {
+    local pager
+    pager=${FORGIT_DIFF_PAGER:-$(git config pager.diff)}
+    if [[ -n $pager ]]; then
+        eval "$pager"
+    else
+        _forgit_page
+    fi
+}
+
+_forgit_show_page() {
+    local pager
+    pager=${FORGIT_SHOW_PAGER:-$(git config pager.show)}
+    if [[ -n $pager ]]; then
+        eval "$pager"
+    else
+        _forgit_page
+    fi
+}
+
+_forgit_blame_page() {
+    local pager
+    pager=${FORGIT_BLAME_PAGER:-$(git config pager.blame)}
+    if [[ -n $pager ]]; then
+        eval "$pager"
+    else
+        _forgit_page
+    fi
+}
+
+_forgit_enter_page() {
+    if [[ -n $FORGIT_ENTER_PAGER ]]; then
+        eval "$FORGIT_ENTER_PAGER"
+    else
+        LESS='-r' less
+    fi
+}
 
 _forgit_log_graph_enable=${FORGIT_LOG_GRAPH_ENABLE:-"true"}
 _forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset}
@@ -148,7 +189,7 @@ _forgit_log_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always -U"$_forgit_preview_context" % -- "$@" | $_forgit_show_pager
+    echo "$sha" | xargs -I% git show --color=always -U"$_forgit_preview_context" % -- "$@" | _forgit_show_page
 }
 
 _forgit_log_enter() {
@@ -223,7 +264,7 @@ _forgit_diff_view() {
         IFS=" " read -r -a commits <<< "${*:3}"
     fi
     echo "$input_line" | _forgit_get_files_from_diff_line | xargs -0 \
-        "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | $_forgit_diff_pager
+        "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | _forgit_diff_page
 }
 
 _forgit_edit_diffed_file() {
@@ -264,7 +305,7 @@ _forgit_diff() {
     done
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $_forgit_enter_pager)\"
+        +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $FORGIT enter_page)\"
         --preview=\"$FORGIT diff_view {} '$_forgit_preview_context' $escaped_commits\"
         --bind=\"alt-e:execute-silent($FORGIT edit_diffed_file {})+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
@@ -285,9 +326,9 @@ _forgit_diff() {
 _forgit_add_preview() {
     file=$(echo "$1" | _forgit_get_single_file_from_add_line)
     if (git status -s -- "$file" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
-        git diff --color=always --no-index -- /dev/null "$file" | $_forgit_diff_pager | sed '2 s/added:/untracked:/'
+        git diff --color=always --no-index -- /dev/null "$file" | _forgit_diff_page | sed '2 s/added:/untracked:/'
     else
-        git diff --color=always -- "$file" | $_forgit_diff_pager
+        git diff --color=always -- "$file" | _forgit_diff_page
     fi
 }
 
@@ -339,7 +380,7 @@ _forgit_add() {
 
 _forgit_reset_head_preview() {
     file=$1
-    git diff --staged --color=always -- "$file" | $_forgit_diff_pager
+    git diff --staged --color=always -- "$file" | _forgit_diff_page
 }
 
 _forgit_git_reset_head() {
@@ -377,7 +418,7 @@ _forgit_reset_head() {
 _forgit_stash_show_preview() {
     local stash
     stash=$(echo "$1" | cut -d: -f1)
-    _forgit_git_stash_show "$stash" | $_forgit_diff_pager
+    _forgit_git_stash_show "$stash" | _forgit_diff_page
 }
 
 _forgit_git_stash_show() {
@@ -393,7 +434,7 @@ _forgit_stash_show() {
     _forgit_parse_array _forgit_stash_show_git_opts "$FORGIT_STASH_SHOW_GIT_OPTS"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_preview {} | $_forgit_enter_pager)\"
+        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_preview {} | $FORGIT enter_page)\"
         --bind=\"ctrl-y:execute-silent($FORGIT yank_stash_name {})\"
         --preview=\"$FORGIT stash_show_preview {}\"
         $FORGIT_STASH_FZF_OPTS
@@ -407,9 +448,9 @@ _forgit_stash_show() {
 
 _forgit_stash_push_preview() {
     if _forgit_is_file_tracked "$1"; then
-        git diff --color=always -- "$1" | $_forgit_diff_pager
+        git diff --color=always -- "$1" | _forgit_diff_page
     else
-        git diff --color=always /dev/null "$1" | $_forgit_diff_pager
+        git diff --color=always /dev/null "$1" | _forgit_diff_page
     fi
 }
 
@@ -468,7 +509,7 @@ _forgit_clean() {
 }
 
 _forgit_cherry_pick_preview() {
-    echo "$1" | cut -f2- | _forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager
+    echo "$1" | cut -f2- | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_show_page
 }
 
 _forgit_cherry_pick() {
@@ -585,7 +626,7 @@ _forgit_file_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always % -- "$@" | $_forgit_show_pager
+    echo "$sha" | xargs -I% git show --color=always % -- "$@" | _forgit_show_page
 }
 
 _forgit_fixup() {
@@ -618,7 +659,7 @@ _forgit_fixup() {
 }
 
 _forgit_checkout_file_preview() {
-    git diff --color=always -- "$1" | $_forgit_diff_pager
+    git diff --color=always -- "$1" | _forgit_diff_page
 }
 
 _forgit_git_checkout_file() {
@@ -712,7 +753,7 @@ _forgit_checkout_tag() {
 }
 
 _forgit_checkout_commit_preview() {
-    echo "$1" | _forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager
+    echo "$1" | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_show_page
 }
 
 _forgit_git_checkout_commit() {
@@ -779,7 +820,7 @@ _forgit_revert_preview() {
     cut -f2- |
     _forgit_extract_sha |
     xargs -I% git show --color=always % |
-    $_forgit_show_pager
+    _forgit_show_page
 }
 
 _forgit_git_revert() {
@@ -828,7 +869,7 @@ _forgit_blame_preview() {
     if _forgit_is_file_tracked "$1"; then
         _forgit_blame_git_opts=()
         _forgit_parse_array _forgit_blame_git_opts "$FORGIT_BLAME_GIT_OPTS"
-        git blame "$@" "${_forgit_blame_git_opts[@]}" --date=short | $_forgit_blame_pager
+        git blame "$@" "${_forgit_blame_git_opts[@]}" --date=short | _forgit_blame_page
     else
         echo "File not tracked"
     fi
@@ -867,7 +908,19 @@ export FORGIT_GI_REPO_LOCAL="${FORGIT_GI_REPO_LOCAL:-${XDG_CACHE_HOME:-$HOME/.ca
 export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
 
 _forgit_ignore_preview() {
-    $_forgit_ignore_pager "$FORGIT_GI_TEMPLATES/$1"{,.gitignore} 2>/dev/null
+    files=()
+    files=( "$FORGIT_GI_TEMPLATES/$1"{,.gitignore} )
+    if [[ -n $FORGIT_IGNORE_PAGER ]]; then
+        quoted_files=()
+        for file in "${files[@]}"; do
+            quoted_files+=("'$file'")
+        done
+        eval "$FORGIT_IGNORE_PAGER ${quoted_files[*]}" 2> /dev/null
+    elif hash bat &> /dev/null; then
+        bat -l gitignore --color=always "${files[@]}" 2>/dev/null
+    else
+        cat "${files[@]}" 2> /dev/null
+    fi
 }
 
 _forgit_ignore() {
@@ -961,6 +1014,7 @@ private_commands=(
     "diff_view"
     "edit_diffed_file"
     "edit_add_file"
+    "enter_page"
 )
 
 cmd="$1"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -127,18 +127,30 @@ _forgit_quote_files() {
     echo "${files[*]}"
 }
 
-_forgit_pager=${FORGIT_PAGER:-$(git config core.pager || echo 'cat')}
-_forgit_show_pager=${FORGIT_SHOW_PAGER:-$(git config pager.show || echo "$_forgit_pager")}
-_forgit_diff_pager=${FORGIT_DIFF_PAGER:-$(git config pager.diff || echo "$_forgit_pager")}
-_forgit_ignore_pager=${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -l gitignore --color=always' || echo 'cat')}
-_forgit_blame_pager=${FORGIT_BLAME_PAGER:-$(git config pager.blame || echo "$_forgit_pager")}
-_forgit_enter_pager=${FORGIT_ENTER_PAGER:-"LESS='-r' less"}
-
 _forgit_log_graph_enable=${FORGIT_LOG_GRAPH_ENABLE:-"true"}
 _forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset}
 _forgit_log_preview_options=("--graph" "--pretty=format:$_forgit_log_format" "--color=always" "--abbrev-commit" "--date=relative")
 _forgit_fullscreen_context=${FORGIT_FULLSCREEN_CONTEXT:-10}
 _forgit_preview_context=${FORGIT_PREVIEW_CONTEXT:-3}
+
+_forgit_pager() {
+    local pager
+    pager=$(_forgit_get_pager "$1")
+    [[ -z "${pager}" ]] && exit 1
+    eval "${pager} ${*:2}"
+}
+
+_forgit_get_pager() {
+    case "${1:-core}" in
+        core) echo -n "${FORGIT_PAGER:-$(git config core.pager || echo 'cat')}" ;;
+        show) echo -n "${FORGIT_SHOW_PAGER:-$(git config pager.show || _forgit_get_pager)}" ;;
+        diff) echo -n "${FORGIT_DIFF_PAGER:-$(git config pager.diff || _forgit_get_pager)}" ;;
+        ignore) echo -n "${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -l gitignore --color=always' || echo 'cat')}" ;;
+        blame) echo -n "${FORGIT_BLAME_PAGER:-$(git config pager.blame || _forgit_get_pager)}" ;;
+        enter) echo -n "${FORGIT_ENTER_PAGER:-"LESS='-r' less"}" ;;
+        *) echo "pager not found: $1" >&2 ;;
+    esac
+}
 
 _forgit_is_file_tracked() {
     git ls-files "$1" --error-unmatch &> /dev/null
@@ -148,7 +160,7 @@ _forgit_log_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always -U"$_forgit_preview_context" % -- "$@" | $_forgit_show_pager
+    echo "$sha" | xargs -I% git show --color=always -U"$_forgit_preview_context" % -- "$@" | _forgit_pager show
 }
 
 _forgit_log_enter() {
@@ -223,7 +235,7 @@ _forgit_diff_view() {
         IFS=" " read -r -a commits <<< "${*:3}"
     fi
     echo "$input_line" | _forgit_get_files_from_diff_line | xargs -0 \
-        "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | $_forgit_diff_pager
+        "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | _forgit_pager diff
 }
 
 _forgit_edit_diffed_file() {
@@ -264,7 +276,7 @@ _forgit_diff() {
     done
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $_forgit_enter_pager)\"
+        +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $FORGIT pager enter)\"
         --preview=\"$FORGIT diff_view {} '$_forgit_preview_context' $escaped_commits\"
         --bind=\"alt-e:execute-silent($FORGIT edit_diffed_file {})+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
@@ -285,9 +297,9 @@ _forgit_diff() {
 _forgit_add_preview() {
     file=$(echo "$1" | _forgit_get_single_file_from_add_line)
     if (git status -s -- "$file" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
-        git diff --color=always --no-index -- /dev/null "$file" | $_forgit_diff_pager | sed '2 s/added:/untracked:/'
+        git diff --color=always --no-index -- /dev/null "$file" | _forgit_pager diff | sed '2 s/added:/untracked:/'
     else
-        git diff --color=always -- "$file" | $_forgit_diff_pager
+        git diff --color=always -- "$file" | _forgit_pager diff
     fi
 }
 
@@ -339,7 +351,7 @@ _forgit_add() {
 
 _forgit_reset_head_preview() {
     file=$1
-    git diff --staged --color=always -- "$file" | $_forgit_diff_pager
+    git diff --staged --color=always -- "$file" | _forgit_pager diff
 }
 
 _forgit_git_reset_head() {
@@ -377,7 +389,7 @@ _forgit_reset_head() {
 _forgit_stash_show_preview() {
     local stash
     stash=$(echo "$1" | cut -d: -f1)
-    _forgit_git_stash_show "$stash" | $_forgit_diff_pager
+    _forgit_git_stash_show "$stash" | _forgit_pager diff
 }
 
 _forgit_git_stash_show() {
@@ -393,7 +405,7 @@ _forgit_stash_show() {
     _forgit_parse_array _forgit_stash_show_git_opts "$FORGIT_STASH_SHOW_GIT_OPTS"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_preview {} | $_forgit_enter_pager)\"
+        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_preview {} | $FORGIT pager enter)\"
         --bind=\"ctrl-y:execute-silent($FORGIT yank_stash_name {})\"
         --preview=\"$FORGIT stash_show_preview {}\"
         $FORGIT_STASH_FZF_OPTS
@@ -407,9 +419,9 @@ _forgit_stash_show() {
 
 _forgit_stash_push_preview() {
     if _forgit_is_file_tracked "$1"; then
-        git diff --color=always -- "$1" | $_forgit_diff_pager
+        git diff --color=always -- "$1" | _forgit_pager diff
     else
-        git diff --color=always /dev/null "$1" | $_forgit_diff_pager
+        git diff --color=always /dev/null "$1" | _forgit_pager diff
     fi
 }
 
@@ -468,7 +480,7 @@ _forgit_clean() {
 }
 
 _forgit_cherry_pick_preview() {
-    echo "$1" | cut -f2- | _forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager
+    echo "$1" | cut -f2- | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_pager show
 }
 
 _forgit_cherry_pick() {
@@ -585,7 +597,7 @@ _forgit_file_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always % -- "$@" | $_forgit_show_pager
+    echo "$sha" | xargs -I% git show --color=always % -- "$@" | _forgit_pager show
 }
 
 _forgit_fixup() {
@@ -618,7 +630,7 @@ _forgit_fixup() {
 }
 
 _forgit_checkout_file_preview() {
-    git diff --color=always -- "$1" | $_forgit_diff_pager
+    git diff --color=always -- "$1" | _forgit_pager diff
 }
 
 _forgit_git_checkout_file() {
@@ -712,7 +724,7 @@ _forgit_checkout_tag() {
 }
 
 _forgit_checkout_commit_preview() {
-    echo "$1" | _forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager
+    echo "$1" | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_pager show
 }
 
 _forgit_git_checkout_commit() {
@@ -779,7 +791,7 @@ _forgit_revert_preview() {
     cut -f2- |
     _forgit_extract_sha |
     xargs -I% git show --color=always % |
-    $_forgit_show_pager
+    _forgit_pager show
 }
 
 _forgit_git_revert() {
@@ -828,7 +840,7 @@ _forgit_blame_preview() {
     if _forgit_is_file_tracked "$1"; then
         _forgit_blame_git_opts=()
         _forgit_parse_array _forgit_blame_git_opts "$FORGIT_BLAME_GIT_OPTS"
-        git blame "$@" "${_forgit_blame_git_opts[@]}" --date=short | $_forgit_blame_pager
+        git blame "$@" "${_forgit_blame_git_opts[@]}" --date=short | _forgit_pager blame
     else
         echo "File not tracked"
     fi
@@ -867,7 +879,11 @@ export FORGIT_GI_REPO_LOCAL="${FORGIT_GI_REPO_LOCAL:-${XDG_CACHE_HOME:-$HOME/.ca
 export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
 
 _forgit_ignore_preview() {
-    $_forgit_ignore_pager "$FORGIT_GI_TEMPLATES/$1"{,.gitignore} 2>/dev/null
+    quoted_files=()
+    for file in "$FORGIT_GI_TEMPLATES/$1"{,.gitignore}; do
+        quoted_files+=("'$file'")
+    done
+    _forgit_pager ignore "${quoted_files[@]}" 2>/dev/null
 }
 
 _forgit_ignore() {
@@ -961,6 +977,7 @@ private_commands=(
     "diff_view"
     "edit_diffed_file"
     "edit_add_file"
+    "pager"
 )
 
 cmd="$1"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -127,53 +127,12 @@ _forgit_quote_files() {
     echo "${files[*]}"
 }
 
-_forgit_page() {
-    local pager
-    pager=${FORGIT_PAGER:-$(git config core.pager)}
-    if [[ -n $pager ]]; then
-        eval "$pager"
-    else
-        cat
-    fi
-}
-
-_forgit_diff_page() {
-    local pager
-    pager=${FORGIT_DIFF_PAGER:-$(git config pager.diff)}
-    if [[ -n $pager ]]; then
-        eval "$pager"
-    else
-        _forgit_page
-    fi
-}
-
-_forgit_show_page() {
-    local pager
-    pager=${FORGIT_SHOW_PAGER:-$(git config pager.show)}
-    if [[ -n $pager ]]; then
-        eval "$pager"
-    else
-        _forgit_page
-    fi
-}
-
-_forgit_blame_page() {
-    local pager
-    pager=${FORGIT_BLAME_PAGER:-$(git config pager.blame)}
-    if [[ -n $pager ]]; then
-        eval "$pager"
-    else
-        _forgit_page
-    fi
-}
-
-_forgit_enter_page() {
-    if [[ -n $FORGIT_ENTER_PAGER ]]; then
-        eval "$FORGIT_ENTER_PAGER"
-    else
-        LESS='-r' less
-    fi
-}
+_forgit_pager=${FORGIT_PAGER:-$(git config core.pager || echo 'cat')}
+_forgit_show_pager=${FORGIT_SHOW_PAGER:-$(git config pager.show || echo "$_forgit_pager")}
+_forgit_diff_pager=${FORGIT_DIFF_PAGER:-$(git config pager.diff || echo "$_forgit_pager")}
+_forgit_ignore_pager=${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -l gitignore --color=always' || echo 'cat')}
+_forgit_blame_pager=${FORGIT_BLAME_PAGER:-$(git config pager.blame || echo "$_forgit_pager")}
+_forgit_enter_pager=${FORGIT_ENTER_PAGER:-"LESS='-r' less"}
 
 _forgit_log_graph_enable=${FORGIT_LOG_GRAPH_ENABLE:-"true"}
 _forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset}
@@ -189,7 +148,7 @@ _forgit_log_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always -U"$_forgit_preview_context" % -- "$@" | _forgit_show_page
+    echo "$sha" | xargs -I% git show --color=always -U"$_forgit_preview_context" % -- "$@" | $_forgit_show_pager
 }
 
 _forgit_log_enter() {
@@ -264,7 +223,7 @@ _forgit_diff_view() {
         IFS=" " read -r -a commits <<< "${*:3}"
     fi
     echo "$input_line" | _forgit_get_files_from_diff_line | xargs -0 \
-        "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | _forgit_diff_page
+        "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | $_forgit_diff_pager
 }
 
 _forgit_edit_diffed_file() {
@@ -305,7 +264,7 @@ _forgit_diff() {
     done
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $FORGIT enter_page)\"
+        +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $_forgit_enter_pager)\"
         --preview=\"$FORGIT diff_view {} '$_forgit_preview_context' $escaped_commits\"
         --bind=\"alt-e:execute-silent($FORGIT edit_diffed_file {})+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
@@ -326,9 +285,9 @@ _forgit_diff() {
 _forgit_add_preview() {
     file=$(echo "$1" | _forgit_get_single_file_from_add_line)
     if (git status -s -- "$file" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
-        git diff --color=always --no-index -- /dev/null "$file" | _forgit_diff_page | sed '2 s/added:/untracked:/'
+        git diff --color=always --no-index -- /dev/null "$file" | $_forgit_diff_pager | sed '2 s/added:/untracked:/'
     else
-        git diff --color=always -- "$file" | _forgit_diff_page
+        git diff --color=always -- "$file" | $_forgit_diff_pager
     fi
 }
 
@@ -380,7 +339,7 @@ _forgit_add() {
 
 _forgit_reset_head_preview() {
     file=$1
-    git diff --staged --color=always -- "$file" | _forgit_diff_page
+    git diff --staged --color=always -- "$file" | $_forgit_diff_pager
 }
 
 _forgit_git_reset_head() {
@@ -418,7 +377,7 @@ _forgit_reset_head() {
 _forgit_stash_show_preview() {
     local stash
     stash=$(echo "$1" | cut -d: -f1)
-    _forgit_git_stash_show "$stash" | _forgit_diff_page
+    _forgit_git_stash_show "$stash" | $_forgit_diff_pager
 }
 
 _forgit_git_stash_show() {
@@ -434,7 +393,7 @@ _forgit_stash_show() {
     _forgit_parse_array _forgit_stash_show_git_opts "$FORGIT_STASH_SHOW_GIT_OPTS"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_preview {} | $FORGIT enter_page)\"
+        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_preview {} | $_forgit_enter_pager)\"
         --bind=\"ctrl-y:execute-silent($FORGIT yank_stash_name {})\"
         --preview=\"$FORGIT stash_show_preview {}\"
         $FORGIT_STASH_FZF_OPTS
@@ -448,9 +407,9 @@ _forgit_stash_show() {
 
 _forgit_stash_push_preview() {
     if _forgit_is_file_tracked "$1"; then
-        git diff --color=always -- "$1" | _forgit_diff_page
+        git diff --color=always -- "$1" | $_forgit_diff_pager
     else
-        git diff --color=always /dev/null "$1" | _forgit_diff_page
+        git diff --color=always /dev/null "$1" | $_forgit_diff_pager
     fi
 }
 
@@ -509,7 +468,7 @@ _forgit_clean() {
 }
 
 _forgit_cherry_pick_preview() {
-    echo "$1" | cut -f2- | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_show_page
+    echo "$1" | cut -f2- | _forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager
 }
 
 _forgit_cherry_pick() {
@@ -626,7 +585,7 @@ _forgit_file_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always % -- "$@" | _forgit_show_page
+    echo "$sha" | xargs -I% git show --color=always % -- "$@" | $_forgit_show_pager
 }
 
 _forgit_fixup() {
@@ -659,7 +618,7 @@ _forgit_fixup() {
 }
 
 _forgit_checkout_file_preview() {
-    git diff --color=always -- "$1" | _forgit_diff_page
+    git diff --color=always -- "$1" | $_forgit_diff_pager
 }
 
 _forgit_git_checkout_file() {
@@ -753,7 +712,7 @@ _forgit_checkout_tag() {
 }
 
 _forgit_checkout_commit_preview() {
-    echo "$1" | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_show_page
+    echo "$1" | _forgit_extract_sha | xargs -I% git show --color=always % | $_forgit_show_pager
 }
 
 _forgit_git_checkout_commit() {
@@ -820,7 +779,7 @@ _forgit_revert_preview() {
     cut -f2- |
     _forgit_extract_sha |
     xargs -I% git show --color=always % |
-    _forgit_show_page
+    $_forgit_show_pager
 }
 
 _forgit_git_revert() {
@@ -869,7 +828,7 @@ _forgit_blame_preview() {
     if _forgit_is_file_tracked "$1"; then
         _forgit_blame_git_opts=()
         _forgit_parse_array _forgit_blame_git_opts "$FORGIT_BLAME_GIT_OPTS"
-        git blame "$@" "${_forgit_blame_git_opts[@]}" --date=short | _forgit_blame_page
+        git blame "$@" "${_forgit_blame_git_opts[@]}" --date=short | $_forgit_blame_pager
     else
         echo "File not tracked"
     fi
@@ -908,19 +867,7 @@ export FORGIT_GI_REPO_LOCAL="${FORGIT_GI_REPO_LOCAL:-${XDG_CACHE_HOME:-$HOME/.ca
 export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
 
 _forgit_ignore_preview() {
-    files=()
-    files=( "$FORGIT_GI_TEMPLATES/$1"{,.gitignore} )
-    if [[ -n $FORGIT_IGNORE_PAGER ]]; then
-        quoted_files=()
-        for file in "${files[@]}"; do
-            quoted_files+=("'$file'")
-        done
-        eval "$FORGIT_IGNORE_PAGER ${quoted_files[*]}" 2> /dev/null
-    elif hash bat &> /dev/null; then
-        bat -l gitignore --color=always "${files[@]}" 2>/dev/null
-    else
-        cat "${files[@]}" 2> /dev/null
-    fi
+    $_forgit_ignore_pager "$FORGIT_GI_TEMPLATES/$1"{,.gitignore} 2>/dev/null
 }
 
 _forgit_ignore() {
@@ -1014,7 +961,6 @@ private_commands=(
     "diff_view"
     "edit_diffed_file"
     "edit_add_file"
-    "enter_page"
 )
 
 cmd="$1"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -141,7 +141,9 @@ _forgit_pager() {
 }
 
 _forgit_get_pager() {
-    case "${1:-core}" in
+    local pager
+    pager=${1:-core}
+    case "$pager" in
         core) echo -n "${FORGIT_PAGER:-$(git config core.pager || echo 'cat')}" ;;
         show) echo -n "${FORGIT_SHOW_PAGER:-$(git config pager.show || _forgit_get_pager)}" ;;
         diff) echo -n "${FORGIT_DIFF_PAGER:-$(git config pager.diff || _forgit_get_pager)}" ;;


### PR DESCRIPTION
## Check list

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Our pager variables, e.g. `$_forgit_blame_pager` used to be in deferred code blocks that were evaluated with `eval`. Since we've removed the usage of `eval` in #326, variables in the pagers no longer get expanded, as is the case with #380.
In this specific case, evaluation is what we want and deferred code is unavoidable if we do not want to cut down on existing functionality, since the pagers are defined outside forgit (either in the git config or in an environment variable). The most straight forward approach to solving this would probably be to introduce `eval` everywhere we use the pager variables, e.g.

```diff
- "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | $_forgit_diff_pager
+ "$FORGIT" exec_diff "${commits[@]}" -U"$diff_context" -- | eval "$_forgit_diff_pager"
```
However, this solution is ugly in my eyes and I'm concerned it reintroduces the anti-pattern of `eval`/deferred code that we got rid of in #326.
So here is an attempt to solve this issue while keeping the amount of deferred code and usage of `eval` as low as possible.

The code here is not final by any means and not tested thoroughly. This is a draft to start a discussion on how we want to solve this issue. Would highly appreciate your thoughts on this @wfxr, @cjappl & @carlfriedrich.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
