### PR TITLE
Do not disable shellcheck 2206 and 2068 in _forgit_ignore

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -876,8 +876,7 @@ _forgit_ignore() {
         --preview=\"$FORGIT ignore_preview {2}\"
         $FORGIT_IGNORE_FZF_OPTS
     "
-    # shellcheck disable=SC2206
-    args=($@)
+    args=("$@")
     if [[ $# -eq 0 ]]; then
         args=()
         while IFS='' read -r arg; do
@@ -886,8 +885,7 @@ _forgit_ignore() {
             FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}')
     fi
     [ ${#args[@]} -eq 0 ] && return 1
-    # shellcheck disable=SC2068
-    _forgit_ignore_get ${args[@]}
+    _forgit_ignore_get "${args[@]}"
 }
 _forgit_ignore_update() {
     if [[ -d "$FORGIT_GI_REPO_LOCAL" ]]; then


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Shellcheck [2206](https://www.shellcheck.net/wiki/SC2206) and [2068](https://www.shellcheck.net/wiki/SC2068) have been disabled in `_forgit_ignore` for a very long time. The code that triggers the shellchecks was added in ce240ac before the shelllcheck action had been added. The shellceck for the lines in question got disabled in c14ce93. The commit message does not state why, but I'm guessing that this has been done simply to make the CI pass. I do not think disabling the shellchecks is necessary here. I've implemented the fixes shellcheck suggest and I could not find any issues with it.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
