### PR TITLE
Add a preview to _forgit_clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ export FORGIT_LOG_FZF_OPTS='
 | `FORGIT_LOG_FORMAT`         | git log format                           | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
 | `FORGIT_PREVIEW_CONTEXT`    | lines of diff context in preview mode    | 3                                             |
 | `FORGIT_FULLSCREEN_CONTEXT` | lines of diff context in fullscreen mode | 10                                            |
+| `FORGIT_DIR_VIEW`           | command used to preview directories      | `tree` if available, otherwise `find`         |
 
 # 📦 Optional dependencies
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -471,9 +471,17 @@ _forgit_stash_push() {
 }
 
 _forgit_clean_preview() {
-    local file
-    file=$1
-    git diff --color=always /dev/null "$file" | _forgit_pager diff
+    local path
+    path=$1
+    if [[ -d "$path" ]]; then
+        if hash tree &> /dev/null; then
+            tree "$path"
+        else
+            find "$path"
+        fi
+    else
+        git diff --color=always /dev/null "$path" | _forgit_pager diff
+    fi
 }
 
 # git clean selector

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -132,6 +132,7 @@ _forgit_log_format=${FORGIT_LOG_FORMAT:-%C(auto)%h%d %s %C(black)%C(bold)%cr%Cre
 _forgit_log_preview_options=("--graph" "--pretty=format:$_forgit_log_format" "--color=always" "--abbrev-commit" "--date=relative")
 _forgit_fullscreen_context=${FORGIT_FULLSCREEN_CONTEXT:-10}
 _forgit_preview_context=${FORGIT_PREVIEW_CONTEXT:-3}
+_forgit_dir_view=${FORGIT_DIR_VIEW:-$(hash tree &> /dev/null && echo 'tree' || echo 'find')}
 
 _forgit_pager() {
     local pager
@@ -474,11 +475,7 @@ _forgit_clean_preview() {
     local path
     path=$1
     if [[ -d "$path" ]]; then
-        if hash tree &> /dev/null; then
-            tree "$path"
-        else
-            find "$path"
-        fi
+        eval "$_forgit_dir_view \"$path\""
     else
         git diff --color=always /dev/null "$path" | _forgit_pager diff
     fi

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -470,6 +470,12 @@ _forgit_stash_push() {
     _forgit_git_stash_push ${msg:+-m "$msg"} -u "${files[@]}"
 }
 
+_forgit_clean_preview() {
+    local file
+    file=$1
+    git diff --color=always /dev/null "$file" | _forgit_pager diff
+}
+
 # git clean selector
 _forgit_clean() {
     _forgit_inside_work_tree || return 1
@@ -479,6 +485,7 @@ _forgit_clean() {
     _forgit_parse_array _forgit_clean_git_opts "$FORGIT_CLEAN_GIT_OPTS"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
+        --preview=\"$FORGIT clean_preview {}\"
         -m -0
         $FORGIT_CLEAN_FZF_OPTS
     "
@@ -975,6 +982,7 @@ private_commands=(
     "checkout_file_preview"
     "cherry_pick_from_branch_preview"
     "cherry_pick_preview"
+    "clean_preview"
     "diff_enter"
     "file_preview"
     "ignore_preview"


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

`gclean` is the only command that does not display a preview. I sometimes find myself exiting `gclean` just to check the content of a file before deleting it. Being able to have a last peek at a file before removing it does sound like a good idea in general to me.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
