### PR TITLE
Move fzf options into $opts variables

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -458,6 +458,7 @@ _forgit_stash_push() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m
+        --preview=\"$FORGIT stash_push_preview {}\"
         $FORGIT_STASH_PUSH_FZF_OPTS
     "
     # Show both modified and untracked files
@@ -465,7 +466,7 @@ _forgit_stash_push() {
     while IFS='' read -r file; do
         files+=("$file")
     done < <(git ls-files --exclude-standard --modified --others |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT stash_push_preview {}")
+        FZF_DEFAULT_OPTS="$opts" fzf)
     [[ "${#files[@]}" -eq 0 ]] && return 1
     _forgit_git_stash_push ${msg:+-m "$msg"} -u "${files[@]}"
 }
@@ -820,8 +821,9 @@ _forgit_revert_commit() {
 
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s --tiebreak=index
+        -m +s --tiebreak=index
         --ansi --with-nth 2..
+        --preview=\"$FORGIT revert_preview {}\"
         $FORGIT_REVERT_COMMIT_FZF_OPTS
     "
 
@@ -837,7 +839,7 @@ _forgit_revert_commit() {
         git log --graph --color=always --format="$_forgit_log_format" |
         _forgit_emojify |
         nl |
-        FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT revert_preview {}" -m |
+        FZF_DEFAULT_OPTS="$opts" fzf |
         sort -n -k 1 | 
         cut -f2- |
         sed 's/^[^a-f^0-9]*\([a-f0-9]*\).*/\1/')
@@ -868,17 +870,18 @@ _forgit_blame() {
     _forgit_inside_work_tree || return 1
     local opts flags file
     _forgit_contains_non_flags "$@" && { _forgit_git_blame "$@"; return $?; }
-    opts="
-        $FORGIT_FZF_DEFAULT_OPTS
-        $FORGIT_BLAME_FZF_OPTS
-    "
     flags=()
     while IFS='' read -r flag; do
         flags+=("$flag")
     done < <(git rev-parse --flags "$@")
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        --preview=\"$FORGIT blame_preview {} ${flags[*]}\"
+        $FORGIT_BLAME_FZF_OPTS
+    "
     # flags is not quoted here, which is fine given that they are retrieved
     # with git rev-parse and can only contain flags
-    file=$(FZF_DEFAULT_OPTS="$opts" fzf --preview="$FORGIT blame_preview {} ${flags[*]}")
+    file=$(FZF_DEFAULT_OPTS="$opts" fzf)
     [[ -z "$file" ]] && return 1
     _forgit_git_blame "$file" "${flags[@]}"
 }


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

`_forgit_stash_push`, `_forgit_revert_commit` and `_forgit_blame` passed some fzf options as arguments directly instead of defining them in the `$opts` variable, as we do everywhere else. This change makes these functions consistent with the rest of the code base and additionally allows overriding said options with the respective `$FORGIT_*_FZF_OPTS` environment variables.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
