### PR TITLE
Fix: --date option in gbl can not be overridden anymore

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -851,7 +851,7 @@ _forgit_blame_preview() {
     if _forgit_is_file_tracked "$1"; then
         _forgit_blame_git_opts=()
         _forgit_parse_array _forgit_blame_git_opts "$FORGIT_BLAME_GIT_OPTS"
-        git blame "$@" "${_forgit_blame_git_opts[@]}" --date=short | _forgit_pager blame
+        git blame --date=short "${_forgit_blame_git_opts[@]}" "$@" | _forgit_pager blame
     else
         echo "File not tracked"
     fi


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

The order of the arguments passed to git blame in \_forgit\_blame\_preview has been changed in bfffda6, putting `--date=short` as the last argument instead of the first. This caused it taking precedence of anything defined in $FORGIT\_BLAME\_GIT\_OPTS. This PR restores the order of the arguments to what they were before bfffda6.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
