### PR TITLE
Fix: gsp does not work outside the root directory

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -455,18 +455,19 @@ _forgit_stash_push() {
             *) _forgit_git_stash_push "${args[@]}"; return $?
         esac
     done
-    local opts files
+    local opts files rootdir
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m
         --preview=\"$FORGIT stash_push_preview {}\"
         $FORGIT_STASH_PUSH_FZF_OPTS
     "
+    rootdir=$(git rev-parse --show-toplevel)
     # Show both modified and untracked files
     files=()
     while IFS='' read -r file; do
         files+=("$file")
-    done < <(git ls-files --exclude-standard --modified --others |
+    done < <(git ls-files "$rootdir" --exclude-standard --modified --others |
         FZF_DEFAULT_OPTS="$opts" fzf --exit-0)
     [[ "${#files[@]}" -eq 0 ]] && echo "Nothing to stash" && return 1
     _forgit_git_stash_push ${msg:+-m "$msg"} -u "${files[@]}"


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

`gsp` only works when executing it from the repository's root directory. This commit fixes this by passing the root directory to the `git ls-files` command we use to determine the files that can be stashed, similarly to how we do it in \_forgit\_reset\_head.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
