### PR TITLE
Allow disabling --graph with FORGIT_LOG_GRAPH_ENABLE=false in grc

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -838,6 +838,8 @@ _forgit_revert_commit() {
         --preview=\"$FORGIT revert_preview {}\"
         $FORGIT_REVERT_COMMIT_FZF_OPTS
     "
+    graph=()
+    [[ $_forgit_log_graph_enable == true ]] && graph=(--graph)
 
     # in this function, we do something interesting to maintain proper ordering as it's assumed 
     # you generally want to revert newest->oldest when you multiselect
@@ -848,7 +850,7 @@ _forgit_revert_commit() {
     while IFS='' read -r commit; do
         commits+=("$commit")
     done < <(
-        git log --graph --color=always --format="$_forgit_log_format" |
+        git log "${graph[@]}" --color=always --format="$_forgit_log_format" |
         _forgit_emojify |
         nl |
         FZF_DEFAULT_OPTS="$opts" fzf |


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

We allow disabling the `--graph` option of `git log` when `$FORGIT_LOG_GRAPH_ENABLE=false` is set. This PR makes sure that this is also the case in `_forgit_revert_commit` that has been ignoring this until now.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
