### PR TITLE
Add FORGIT_STASH_SHOW_PREVIEW_GIT_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,18 @@ For linux users `FORGIT_COPY_CMD` should be set to make copy work. Example: `FOR
 Options can be set via environment variables. They have to be **exported** in
 order to be recognized by `forgit`.
 
-For instance, if you want to order branches in `gcb` by the last committed date you could:
+For instance:
+
+- if you want to order branches in `gcb` by the last committed date, you could:
 
 ```shell
 export FORGIT_CHECKOUT_BRANCH_BRANCH_GIT_OPTS='--sort=-committerdate'
+```
+
+- if you want to see a preview of the stashed items in `gss` preview, you could:
+
+```shell
+export FORGIT_STASH_SHOW_PREVIEW_GIT_OPTS="--patch-with-stat --stat-count=10"
 ```
 
 ## shell aliases
@@ -243,7 +251,7 @@ These are passed to the according `git` calls.
 | `gct`    | `FORGIT_CHECKOUT_TAG_GIT_OPTS`                                              |
 | `gco`    | `FORGIT_CHECKOUT_COMMIT_GIT_OPTS`                                           |
 | `grc`    | `FORGIT_REVERT_COMMIT_GIT_OPTS`                                             |
-| `gss`    | `FORGIT_STASH_SHOW_GIT_OPTS`                                                |
+| `gss`    | `FORGIT_STASH_SHOW_GIT_OPTS`, `FORGIT_STASH_SHOW_PREVIEW_GIT_OPTS`          |
 | `gsp`    | `FORGIT_STASH_PUSH_GIT_OPTS`                                                |
 | `gclean` | `FORGIT_CLEAN_GIT_OPTS`                                                     |
 | `grb`    | `FORGIT_REBASE_GIT_OPTS`                                                    |

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -395,7 +395,9 @@ _forgit_reset_head() {
 _forgit_stash_show_preview() {
     local stash
     stash=$(echo "$1" | cut -d: -f1)
-    _forgit_git_stash_show "$stash" | _forgit_pager diff
+    _forgit_stash_show_preview_git_opts=()
+    _forgit_parse_array _forgit_stash_show_preview_git_opts "$FORGIT_STASH_SHOW_PREVIEW_GIT_OPTS"
+    _forgit_git_stash_show "${_forgit_stash_show_preview_git_opts[@]}" -- "$stash" | _forgit_pager diff
 }
 
 _forgit_git_stash_show() {


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

FORGIT_STASH_SHOW_PREVIEW_GIT_OPTS variable can be used to tune the rendering of a stash preview.

The following example allows listing the content of the stash before opening it.

FORGIT_STASH_SHOW_PREVIEW_GIT_OPTS="--patch-with-stat --stat-count=10"

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
