### PR TITLE
Fix: Opening files from diff line when not in project root

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -242,9 +242,11 @@ _forgit_diff_view() {
 }
 
 _forgit_edit_diffed_file() {
-    local input_line=$1
+    local input_line rootdir
+    input_line=$1
+    rootdir=$(git rev-parse --show-toplevel)
     filename=$(echo "$input_line" | _forgit_get_single_file_from_diff_line)
-    $EDITOR "$filename" >/dev/tty </dev/tty
+    $EDITOR "$rootdir/$filename" >/dev/tty </dev/tty
 }
 
 _forgit_diff_enter() {


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

When trying to open a file from gd in $EDITOR (alt + e) the wrong file was being opened when the command wasn't executed from the repository's root directory.
Fixes #392

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
- [ ] bash
- [X] zsh
- [ ] fish
- OS
- [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
