### PR TITLE
ci: add dependabot update for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

Currently there still are actions that need to be updated due to the deprecation of Node.js 16 on runners: https://github.com/wfxr/forgit/actions/runs/8903375722
By adding a dependabot configuration the GitHub actions used by workflows of this repository will stay up to date.
All configuration options are documented on [https://docs.github.com](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [x] Others: GitHub Action Runners
