### PR TITLE
refactor: remove -u option from git status in forgit add

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -348,7 +348,7 @@ _forgit_add() {
     _forgit_inside_work_tree || return 1
     local changed unmerged untracked files opts
     # Add files if passed as arguments
-    [[ $# -ne 0 ]] && { _forgit_git_add "$@" && git status -su; return $?; }
+    [[ $# -ne 0 ]] && { _forgit_git_add "$@" && git status -s; return $?; }
 
     changed=$(git config --get-color color.status.changed red)
     unmerged=$(git config --get-color color.status.unmerged red)
@@ -368,7 +368,7 @@ _forgit_add() {
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf |
         _forgit_get_single_file_from_add_line)
-    [[ "${#files[@]}" -gt 0 ]] && _forgit_git_add "${files[@]}" && git status -su && return
+    [[ "${#files[@]}" -gt 0 ]] && _forgit_git_add "${files[@]}" && git status -s && return
     echo 'Nothing to add.'
 }
 


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

I found that all untracked files will always be listed recursively after `forgit add` is called. This is annoying when there are some untracked directories with lots of files in a repo. Useful information will be flushed out by these untracked files. This patch removed the `-u` option from `git status` to just list the untracked directory itself.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
