### PR TITLE
Feature: Add interactive git reflog

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Install `forgit` in just one click.
 
 - **Interactive `git rebase -i` selector** (`grb`)
 
+- **Interactive `git reflog` viewer** (`grl`)
+
 - **Interactive `git blame` selector** (`gbl`)
 
 - **Interactive `git commit --fixup && git rebase -i --autosquash` selector** (`gfu`)
@@ -176,6 +178,7 @@ You can change the default aliases by defining these variables below.
 
 ``` bash
 forgit_log=glo
+forgit_reflog=grl
 forgit_diff=gd
 forgit_add=ga
 forgit_reset_head=grh
@@ -235,6 +238,7 @@ These are passed to the according `git` calls.
 | -------- | --------------------------------------------------------------------------- |
 | `ga`     | `FORGIT_ADD_GIT_OPTS`                                                       |
 | `glo`    | `FORGIT_LOG_GIT_OPTS`                                                       |
+| `grl`    | `FORGIT_REFLOG_GIT_OPTS`                                                    |
 | `gd`     | `FORGIT_DIFF_GIT_OPTS`                                                      |
 | `grh`    | `FORGIT_RESET_HEAD_GIT_OPTS`                                                |
 | `gcf`    | `FORGIT_CHECKOUT_FILE_GIT_OPTS`                                             |
@@ -287,6 +291,7 @@ Customizing fzf options for each command individually is also supported:
 |----------|-----------------------------------|
 | `ga`     | `FORGIT_ADD_FZF_OPTS`             |
 | `glo`    | `FORGIT_LOG_FZF_OPTS`             |
+| `grl`    | `FORGIT_REFLOG_FZF_OPTS`          |
 | `gi`     | `FORGIT_IGNORE_FZF_OPTS`          |
 | `gd`     | `FORGIT_DIFF_FZF_OPTS`            |
 | `grh`    | `FORGIT_RESET_HEAD_FZF_OPTS`      |

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -215,6 +215,31 @@ _forgit_log() {
     return $fzf_exit_code
 }
 
+# git reflog viewer
+_forgit_reflog() {
+    _forgit_inside_work_tree || return 1
+    _forgit_contains_non_flags "$@" && { git reflog "$@"; return $?; }
+    local opts reflog_format
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        +s +m --tiebreak=index
+        --bind=\"enter:execute($FORGIT log_enter {})\"
+        --bind=\"ctrl-y:execute-silent($FORGIT yank_sha {})\"
+        --preview=\"$FORGIT log_preview {}\"
+        $FORGIT_REFLOG_FZF_OPTS
+    "
+    reflog_format=${FORGIT_GRL_FORMAT:-$_forgit_log_format}
+    _forgit_reflog_git_opts=()
+    _forgit_parse_array _forgit_reflog_git_opts "$FORGIT_REFLOG_GIT_OPTS"
+    git reflog show --color=always --format="$reflog_format" "${_forgit_reflog_git_opts[@]}" "$@" |
+        _forgit_emojify |
+        FZF_DEFAULT_OPTS="$opts" fzf
+    fzf_exit_code=$?
+    # exit successfully on 130 (ctrl-c/esc)
+    [[ $fzf_exit_code == 130 ]] && return 0
+    return $fzf_exit_code
+}
+
 _forgit_get_files_from_diff_line() {
     # Construct a null-terminated list of the filenames
     # The input looks like one of these lines:
@@ -992,6 +1017,7 @@ public_commands=(
     "fixup"
     "ignore"
     "log"
+    "reflog"
     "rebase"
     "reset_head"
     "revert_commit"

--- a/completions/_git-forgit
+++ b/completions/_git-forgit
@@ -35,6 +35,12 @@ _git-staged() {
 	_alternative "files:filename:($(git diff --name-only --staged))"
 }
 
+_git-forgit-reflog() {
+	declare -a cmds
+	cmds=('expire:prune old reflog entries' 'delete:delete entries from reflog' 'show:show log of ref' 'exists:check whether a ref has a reflog') 
+	_alternative 'cmds:: _describe -t cmds cmd cmds' 'refs:: __git_references'
+}
+
 _git-forgit() {
 	local subcommand cmd
 	subcommand="${words[1]}"
@@ -65,6 +71,7 @@ _git-forgit() {
 			'fixup:git fixup'
 			'ignore:git ignore generator'
 			'log:git commit viewer'
+			'reflog:git reflog viewer'
 			'rebase:git rebase'
 			'reset_head:git reset HEAD (unstage) selector'
 			'revert_commit:git revert commit selector'
@@ -85,6 +92,7 @@ _git-forgit() {
 	diff) _git-forgit-diff ;;
 	fixup) __git_branch_names ;;
 	log) _git-log ;;
+	reflog) _git-forgit-reflog ;;
 	rebase) _git-rebase ;;
 	reset_head) _git-staged ;;
 	revert_commit) __git_recent_commits ;;
@@ -109,6 +117,7 @@ compdef _git-clean forgit::clean
 compdef _git-forgit-diff forgit::diff
 compdef __git_branch_names forgit::fixup
 compdef _git-log forgit::log
+compdef _git-reflog forgit::reflog
 compdef _git-rebase forgit::rebase
 compdef _git-staged forgit::reset::head
 compdef __git_recent_commits forgit::revert::commit

--- a/completions/git-forgit.bash
+++ b/completions/git-forgit.bash
@@ -71,6 +71,7 @@ _git_forgit()
 		fixup
 		ignore
 		log
+		reflog
 		rebase
 		reset_head
 		revert_commit
@@ -96,6 +97,7 @@ _git_forgit()
 				diff) _git_diff ;;
 				fixup) _git_branch ;;
 				log) _git_log ;;
+				reflog) _git_reflog ;;
 				rebase) _git_rebase ;;
 				reset_head) _git_reset ;;
 				revert_commit) _git_revert ;;
@@ -129,6 +131,7 @@ then
 	__git_complete forgit::diff _git_diff
 	__git_complete forgit::fixup _git_branch
 	__git_complete forgit::log _git_log
+	__git_complete forgit::reflog _git_reflog
 	__git_complete forgit::rebase _git_rebase
 	__git_complete forgit::reset::head _git_reset
 	__git_complete forgit::revert::commit _git_revert
@@ -147,6 +150,7 @@ then
 		__git_complete "${forgit_diff}" _git_diff
 		__git_complete "${forgit_fixup}" _git_branch
 		__git_complete "${forgit_log}" _git_log
+		__git_complete "${forgit_reflog}" _git_reflog
 		__git_complete "${forgit_rebase}" _git_rebase
 		__git_complete "${forgit_reset_head}" _git_reset
 		__git_complete "${forgit_revert_commit}" _git_revert

--- a/completions/git-forgit.fish
+++ b/completions/git-forgit.fish
@@ -7,8 +7,8 @@
 
 function __fish_forgit_needs_subcommand
     for subcmd in add blame branch_delete checkout_branch checkout_commit checkout_file checkout_tag \
-        cherry_pick cherry_pick_from_branch clean diff fixup ignore log rebase reset_head revert_commit \
-        stash_show stash_push
+        cherry_pick cherry_pick_from_branch clean diff fixup ignore log reflog rebase reset_head \
+        revert_commit stash_show stash_push
         if contains -- $subcmd (commandline -opc)
             return 1
         end
@@ -36,6 +36,7 @@ complete -c git-forgit -n __fish_forgit_needs_subcommand -a diff -d 'git diff vi
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a fixup -d 'git fixup'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a ignore -d 'git ignore generator'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a log -d 'git commit viewer'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a reflog -d 'git reflog viewer'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a rebase -d 'git rebase'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a reset_head -d 'git reset HEAD (unstage) selector'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a revert_commit -d 'git revert commit selector'
@@ -52,6 +53,7 @@ complete -c git-forgit -n '__fish_seen_subcommand_from cherry_pick' -a "(complet
 complete -c git-forgit -n '__fish_seen_subcommand_from clean' -a "(__fish_git_files untracked ignored)"
 complete -c git-forgit -n '__fish_seen_subcommand_from fixup' -a "(__fish_git_local_branches)"
 complete -c git-forgit -n '__fish_seen_subcommand_from log' -a "(complete -C 'git log ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from reflog' -a "(complete -C 'git reflog ')"
 complete -c git-forgit -n '__fish_seen_subcommand_from rebase' -a "(complete -C 'git rebase ')"
 complete -c git-forgit -n '__fish_seen_subcommand_from reset_head' -a "(__fish_git_files all-staged)"
 complete -c git-forgit -n '__fish_seen_subcommand_from revert_commit' -a "(__fish_git_commits)"

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -35,6 +35,7 @@ if test -z "$FORGIT_NO_ALIASES"
     abbr -a -- (string collect $forgit_add; or string collect "ga") git-forgit add
     abbr -a -- (string collect $forgit_reset_head; or string collect "grh") git-forgit reset_head
     abbr -a -- (string collect $forgit_log; or string collect "glo") git-forgit log
+    abbr -a -- (string collect $forgit_reflog; or string collect "grl") git-forgit reflog
     abbr -a -- (string collect $forgit_diff; or string collect "gd") git-forgit diff
     abbr -a -- (string collect $forgit_ignore; or string collect "gi") git-forgit ignore
     abbr -a -- (string collect $forgit_checkout_file; or string collect "gcf") git-forgit checkout_file

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -45,6 +45,10 @@ forgit::log() {
     "$FORGIT" log "$@"
 }
 
+forgit::reflog() {
+    "$FORGIT" reflog "$@"
+}
+
 forgit::diff() {
     "$FORGIT" diff "$@"
 }
@@ -140,6 +144,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     export forgit_add="${forgit_add:-ga}"
     export forgit_reset_head="${forgit_reset_head:-grh}"
     export forgit_log="${forgit_log:-glo}"
+    export forgit_reflog="${forgit_reflog:-grl}"
     export forgit_diff="${forgit_diff:-gd}"
     export forgit_ignore="${forgit_ignore:-gi}"
     export forgit_checkout_file="${forgit_checkout_file:-gcf}"
@@ -159,6 +164,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     alias "${forgit_add}"='forgit::add'
     alias "${forgit_reset_head}"='forgit::reset::head'
     alias "${forgit_log}"='forgit::log'
+    alias "${forgit_reflog}"='forgit::reflog'
     alias "${forgit_diff}"='forgit::diff'
     alias "${forgit_ignore}"='forgit::ignore'
     alias "${forgit_checkout_file}"='forgit::checkout::file'


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

I do not use `git reflog` very often but when I do, I really miss forgits ergonomics - time to fix that!
The `git reflog` command is very similar to `git log` in almost every way, so I kept my implementation very close to `_forgit_log`. I was even able to reuse the `log_enter` and `log_preview` functions for it. The usage in forgit is exactly the same as with `_forgit_log`.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
