### PR TITLE
Meta: do not create release when there are no public changes

### DIFF
--- a/.github/scripts/changelog.sh
+++ b/.github/scripts/changelog.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+release_has_public_changes=false
+
 url=$(git remote get-url origin | sed -r 's/(.*)\.git/\1/')
 
 previous_tag=$(git describe --tags --abbrev=0 HEAD~)
@@ -23,5 +25,12 @@ do
             # Escape markdown formatting symbols _ * `
             echo "  $line" | sed 's/_/\\_/g' | sed 's/`/\\`/g' | sed 's/\*/\\\*/g'
         done
+        release_has_public_changes=true
     fi
 done
+
+if ! $release_has_public_changes
+then
+    echo "No public changes since $previous_tag." >&2
+    exit 1
+fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,13 @@ jobs:
         run: tar -czf forgit-${{github.ref_name}}.tar.gz --exclude LICENSE --exclude README.md *
 
       - name: Generate Changelog
+        id: changelog
         run: .github/scripts/changelog.sh > CHANGELOG.md
+        continue-on-error: true
 
       - name: Release
         uses: softprops/action-gh-release@v2
+        if: steps.changelog.outcome == 'success'
         with:
           body_path: CHANGELOG.md
           files: forgit-${{github.ref_name}}.tar.gz


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

The latest forgit release did not contain any release notes, because the only commit since the previous release had the `Meta` prefix in its git summary, and we do not include these commits in the release notes.

In such a case we should not create a release at all, since we do not have any code changes. I fixed this in the GHA jobs and tested it in my private fork. Will merge this next week if no complaints come in.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
