### PR TITLE
fix: fix edit file key binding (alt-e) in diff and add

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -323,7 +323,7 @@ _forgit_diff() {
         $FORGIT_FZF_DEFAULT_OPTS
         +m -0 --bind=\"enter:execute($FORGIT diff_enter {} $escaped_commits | $FORGIT pager enter)\"
         --preview=\"$FORGIT diff_view {} '$_forgit_preview_context' $escaped_commits\"
-        --bind=\"alt-e:execute-silent($FORGIT edit_diffed_file {})+refresh-preview\"
+        --bind=\"alt-e:execute($FORGIT edit_diffed_file {})+refresh-preview\"
         $FORGIT_DIFF_FZF_OPTS
         --prompt=\"${commits[*]} > \"
     "
@@ -382,7 +382,7 @@ _forgit_add() {
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
         --preview=\"$FORGIT add_preview {}\"
-        --bind=\"alt-e:execute-silent($FORGIT edit_add_file {})+refresh-preview\"
+        --bind=\"alt-e:execute($FORGIT edit_add_file {})+refresh-preview\"
         $FORGIT_ADD_FZF_OPTS
     "
     files=()


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description

The key binding `alt-e` for editing a file in diff and add was not working properly on recent versions of fzf. As its documentation suggests, we should replace `execute-silent` with `execute` since we need to switch to a new screen and handle both input and output.

> fzf switches to the alternate screen when executing a command. However, if the command is expected to complete quickly, and you are not interested in its output, you might want to use execute-silent instead, which silently executes the command without the switching.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
