### PR TITLE
Meta: add tree as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,8 @@ export FORGIT_LOG_FZF_OPTS='
 
 - [`emoji-cli`](https://github.com/wfxr/emoji-cli): Emoji support for `git log`.
 
+- [`tree`](https://gitlab.com/OldManProgrammer/unix-tree): Directory tree view for `gclean`.
+
 # Completions
 
 ## Bash


### PR DESCRIPTION
## Check list

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

We've added an optional dependency for `tree` with #383, but never mentioned this in the README.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [X] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
