### PR TITLE
Refactor: Remove _forgit_ignore_clean

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -1089,10 +1089,6 @@ _forgit_ignore_get() {
 _forgit_ignore_list() {
     find "$FORGIT_GI_TEMPLATES" -print |sed -e 's#.gitignore$##' -e 's#.*/##' | sort -fu
 }
-_forgit_ignore_clean() {
-    setopt localoptions rmstarsilent
-    [[ -d "$FORGIT_GI_REPO_LOCAL" ]] && rm -rf "$FORGIT_GI_REPO_LOCAL"
-}
 
 public_commands=(
     "add"


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Removing `_forgit_ignore_clean`. As discussed in #407, this function has been unused for a long time.

Closes #407

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
