### PR TITLE
Allow passing arguments to git rebase

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -724,17 +724,16 @@ _forgit_cherry_pick_from_branch() {
 
 _forgit_rebase() {
     _forgit_inside_work_tree || return 1
-    local opts graph quoted_files target_commit prev_commit
+    local opts graph target_commit prev_commit
     graph=()
     [[ $_forgit_log_graph_enable == true ]] && graph=(--graph)
     _forgit_rebase_git_opts=()
     _forgit_parse_array _forgit_rebase_git_opts "$FORGIT_REBASE_GIT_OPTS"
-    quoted_files=$(_forgit_quote_files "$@")
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
         --bind=\"ctrl-y:execute-silent($FORGIT yank_sha {})\"
-        --preview=\"$FORGIT file_preview {} $quoted_files\"
+        --preview=\"$FORGIT file_preview {}\"
         $FORGIT_REBASE_FZF_OPTS
     "
     target_commit=$(

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -724,6 +724,7 @@ _forgit_cherry_pick_from_branch() {
 
 _forgit_rebase() {
     _forgit_inside_work_tree || return 1
+    _forgit_contains_non_flags "$@" && { git rebase "$@"; return $?; }
     local opts graph target_commit prev_commit
     graph=()
     [[ $_forgit_log_graph_enable == true ]] && graph=(--graph)
@@ -737,13 +738,13 @@ _forgit_rebase() {
         $FORGIT_REBASE_FZF_OPTS
     "
     target_commit=$(
-        git log "${graph[@]}" --color=always --format="$_forgit_log_format" "$@" |
+        git log "${graph[@]}" --color=always --format="$_forgit_log_format" |
         _forgit_emojify |
         FZF_DEFAULT_OPTS="$opts" fzf |
         _forgit_extract_sha)
     if [[ -n "$target_commit" ]]; then
         prev_commit=$(_forgit_previous_commit "$target_commit")
-        git rebase -i "${_forgit_rebase_git_opts[@]}" "$prev_commit"
+        git rebase -i "${_forgit_rebase_git_opts[@]}" "$@" "$prev_commit"
     fi
 }
 


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

If non-option arguments are passed to `git forgit rebase`, pass them
through directly to `git rebase`, without launching the interactive
selector, just like we do for other forgit commands.

Along with this, I removed the possibility to pass files to rebase.
IMO there is no need to pass files to rebase. I assume this was a copy-paste
error when the rebase function was introduced in the first place.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
