### PR TITLE
Add unstage command as an alias to git reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Then add the following to your shell's config file:
 
 ![screenshot](https://raw.githubusercontent.com/wfxr/i/master/forgit-ga.png)
 
+- **Interactive `git reset` selector, aliased as "unstage"** (`gu`)
+
+// TODO
+
 - **Interactive `git log` viewer** (`glo`)
 
 ![screenshot](https://raw.githubusercontent.com/wfxr/i/master/forgit-glo.png)
@@ -189,6 +193,7 @@ forgit_reflog=grl
 forgit_diff=gd
 forgit_show=gso
 forgit_add=ga
+forgit_unstage=gu
 forgit_reset_head=grh
 forgit_ignore=gi
 forgit_attributes=gat
@@ -246,6 +251,7 @@ These are passed to the according `git` calls.
 | Command  | Option                                                                      |
 | -------- | --------------------------------------------------------------------------- |
 | `ga`     | `FORGIT_ADD_GIT_OPTS`                                                       |
+| `ga`     | `FORGIT_UNSTAGE_GIT_OPTS`                                                       |
 | `glo`    | `FORGIT_LOG_GIT_OPTS`                                                       |
 | `grl`    | `FORGIT_REFLOG_GIT_OPTS`                                                    |
 | `gd`     | `FORGIT_DIFF_GIT_OPTS`                                                      |
@@ -301,6 +307,7 @@ Customizing fzf options for each command individually is also supported:
 | Command  | Option                            |
 |----------|-----------------------------------|
 | `ga`     | `FORGIT_ADD_FZF_OPTS`             |
+| `ga`     | `FORGIT_UNSTAGE_FZF_OPTS`         |
 | `glo`    | `FORGIT_LOG_FZF_OPTS`             |
 | `grl`    | `FORGIT_REFLOG_FZF_OPTS`          |
 | `gi`     | `FORGIT_IGNORE_FZF_OPTS`          |

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -457,7 +457,7 @@ _forgit_git_add() {
 
 _forgit_git_unstage() {
     _forgit_add_git_opts=()
-    _forgit_parse_array _forgit_add_git_opts "$FORGIT_ADD_GIT_OPTS"
+    _forgit_parse_array _forgit_add_git_opts "$FORGIT_UNSTAGE_GIT_OPTS"
     git reset "${_forgit_add_git_opts[@]}" -q HEAD -- "$@"
 }
 
@@ -520,7 +520,7 @@ _forgit_unstage() {
         -0 -m --nth 2..,..
         --preview=\"$FORGIT add_preview {}\"
         --bind=\"alt-e:execute($FORGIT edit_add_file {})+refresh-preview\"
-        $FORGIT_ADD_FZF_OPTS
+        $FORGIT_UNSTAGE_FZF_OPTS
     "
 
     files=()
@@ -1113,7 +1113,7 @@ _forgit_ignore() {
         args=()
         while IFS='' read -r arg; do
             args+=("$arg")
-        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore | 
+        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore |
             nl -w4 -s'  ' |
             FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}')
     fi

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -441,10 +441,24 @@ _forgit_add_preview() {
     fi
 }
 
+_forgit_unstage_preview() {
+    file=$(echo "$1" | _forgit_get_single_file_from_add_line)
+    if (git status -s -- "$file" | grep '^??') &>/dev/null; then  # diff with /dev/null for untracked files
+        git diff --color=always --no-index -- /dev/null "$file" | _forgit_pager diff | sed '2 s/added:/untracked:/'
+    else
+        git diff --color=always -- "$file" | _forgit_pager diff
+    fi
+}
 _forgit_git_add() {
     _forgit_add_git_opts=()
     _forgit_parse_array _forgit_add_git_opts "$FORGIT_ADD_GIT_OPTS"
     git add "${_forgit_add_git_opts[@]}" "$@"
+}
+
+_forgit_git_unstage() {
+    _forgit_add_git_opts=()
+    _forgit_parse_array _forgit_add_git_opts "$FORGIT_ADD_GIT_OPTS"
+    git reset "${_forgit_add_git_opts[@]}" -q HEAD -- "$@"
 }
 
 _forgit_get_single_file_from_add_line() {
@@ -488,6 +502,37 @@ _forgit_add() {
         _forgit_get_single_file_from_add_line)
     [[ "${#files[@]}" -gt 0 ]] && _forgit_git_add "${files[@]}" && git status -s && return
     echo 'Nothing to add.'
+}
+
+# git unstage selector
+_forgit_unstage() {
+    _forgit_inside_work_tree || return 1
+    local changed unmerged untracked files opts
+    # Add files if passed as arguments
+    [[ $# -ne 0 ]] && { _forgit_git_unstage "$@" && git status -s; return $?; }
+
+    changed=$(git config --get-color color.status.changed red)
+    staged=$(git config --get-color color.status.changed green)
+    unmerged=$(git config --get-color color.status.unmerged red)
+    untracked=$(git config --get-color color.status.untracked red)
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        -0 -m --nth 2..,..
+        --preview=\"$FORGIT add_preview {}\"
+        --bind=\"alt-e:execute($FORGIT edit_add_file {})+refresh-preview\"
+        $FORGIT_ADD_FZF_OPTS
+    "
+
+    files=()
+    while IFS='' read -r file; do
+        files+=("$file")
+    done < <(git -c color.status=always -c status.relativePaths=true -c core.quotePath=false status -s |
+        grep -F -e "$staged" |
+        sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
+        FZF_DEFAULT_OPTS="$opts" fzf |
+        _forgit_get_single_file_from_add_line)
+    [[ "${#files[@]}" -gt 0 ]] && _forgit_git_unstage "${files[@]}" && git status -s && return
+    echo 'Nothing to unstage.'
 }
 
 _forgit_reset_head_preview() {
@@ -1068,7 +1113,7 @@ _forgit_ignore() {
         args=()
         while IFS='' read -r arg; do
             args+=("$arg")
-        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore | 
+        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore |
             nl -w4 -s'  ' |
             FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}')
     fi
@@ -1141,6 +1186,7 @@ _forgit_paths_list() {
 public_commands=(
     "add"
     "attributes"
+    "unstage"
     "blame"
     "branch_delete"
     "checkout_branch"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -456,9 +456,9 @@ _forgit_git_add() {
 }
 
 _forgit_git_unstage() {
-    _forgit_add_git_opts=()
-    _forgit_parse_array _forgit_add_git_opts "$FORGIT_UNSTAGE_GIT_OPTS"
-    git reset "${_forgit_add_git_opts[@]}" -q HEAD -- "$@"
+    _forgit_unstage_git_opts=()
+    _forgit_parse_array _forgit_unstage_git_opts "$FORGIT_UNSTAGE_GIT_OPTS"
+    git reset "${_forgit_unstage_git_opts[@]}" -q HEAD -- "$@"
 }
 
 _forgit_get_single_file_from_add_line() {

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -1113,7 +1113,7 @@ _forgit_ignore() {
         args=()
         while IFS='' read -r arg; do
             args+=("$arg")
-        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore |
+        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore | 
             nl -w4 -s'  ' |
             FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}')
     fi

--- a/completions/_git-forgit
+++ b/completions/_git-forgit
@@ -58,6 +58,7 @@ _git-forgit() {
         local -a subcommands
         subcommands=(
             'add:git add selector'
+            'unstage:git unstage selector'
             'blame:git blame viewer'
             'branch_delete:git branch deletion selector'
             'checkout_branch:git checkout branch selector'
@@ -81,6 +82,7 @@ _git-forgit() {
         _describe -t commands 'git forgit' subcommands
         ;;
     add) _git-add ;;
+    unstage) _git-unstage ;;
     branch_delete) _git-branches ;;
     checkout_branch) _git-branches ;;
     checkout_commit) __git_recent_commits ;;
@@ -107,6 +109,7 @@ _git-forgit() {
 (( $+functions[_git-add] )) || return 1
 # Completions for forgit plugin shell functions (also works for aliases)
 compdef _git-add forgit::add
+compdef _git-unstage forgit::unstage
 compdef _git-branches forgit::branch::delete
 compdef _git-branches forgit::checkout::branch
 compdef __git_recent_commits forgit::checkout::commit

--- a/completions/git-forgit.bash
+++ b/completions/git-forgit.bash
@@ -58,6 +58,7 @@ _git_forgit()
 
     cmds="
         add
+        unstage
         blame
         branch_delete
         checkout_branch
@@ -87,6 +88,7 @@ _git_forgit()
         3)
             case ${prev} in
                 add) _git_add ;;
+                _git_unstage ;;
                 branch_delete) _git_branch_delete ;;
                 checkout_branch) _git_checkout_branch ;;
                 checkout_commit) _git_checkout ;;
@@ -122,6 +124,7 @@ then
 
     # Completion for forgit plugin shell functions
     __git_complete forgit::add _git_add
+    __git_complete forgit::unstage _git_unstage
     __git_complete forgit::branch::delete _git_branch_delete
     __git_complete forgit::checkout::branch _git_checkout_branch
     __git_complete forgit::checkout::commit _git_checkout
@@ -143,6 +146,7 @@ then
     # Completion for forgit plugin shell aliases
     if [[ -z "$FORGIT_NO_ALIASES" ]]; then
         __git_complete "${forgit_add}" _git_add
+        __git_complete "${forgit_unstage}" _git_unstage
         __git_complete "${forgit_branch_delete}" _git_branch_delete
         __git_complete "${forgit_checkout_branch}" _git_checkout_branch
         __git_complete "${forgit_checkout_commit}" _git_checkout

--- a/completions/git-forgit.fish
+++ b/completions/git-forgit.fish
@@ -6,7 +6,7 @@
 # sourced when git-forgit command or forgit subcommand of git is invoked.
 
 function __fish_forgit_needs_subcommand
-    for subcmd in add blame branch_delete checkout_branch checkout_commit checkout_file checkout_tag \
+    for subcmd in add unstage blame branch_delete checkout_branch checkout_commit checkout_file checkout_tag \
         cherry_pick cherry_pick_from_branch clean diff fixup ignore log reflog rebase reset_head \
         revert_commit stash_show stash_push
         if contains -- $subcmd (commandline -opc)
@@ -23,6 +23,7 @@ not functions -q __fish_git && source $__fish_data_dir/completions/git.fish
 complete -c git-forgit -x
 
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a add -d 'git add selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a unstage -d 'git unstage selector'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a blame -d 'git blame viewer'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a branch_delete -d 'git branch deletion selector'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a checkout_branch -d 'git checkout branch selector'
@@ -45,6 +46,7 @@ complete -c git-forgit -n __fish_forgit_needs_subcommand -a stash_show -d 'git s
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a stash_push -d 'git stash push selector'
 
 complete -c git-forgit -n '__fish_seen_subcommand_from add' -a "(complete -C 'git add ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from unstage' -a "(complete -C 'git unstage ')"
 complete -c git-forgit -n '__fish_seen_subcommand_from branch_delete' -a "(__fish_git_local_branches)"
 complete -c git-forgit -n '__fish_seen_subcommand_from checkout_branch' -a "(complete -C 'git switch ')"
 complete -c git-forgit -n '__fish_seen_subcommand_from checkout_commit' -a "(__fish_git_commits)"

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -61,6 +61,10 @@ forgit::add() {
     "$FORGIT" add "$@"
 }
 
+forgit::unstage() {
+    "$FORGIT" unstage "$@"
+}
+
 forgit::reset::head() {
     "$FORGIT" reset_head "$@"
 }
@@ -150,6 +154,7 @@ forgit::attributes() {
 if [[ -z "$FORGIT_NO_ALIASES" ]]; then
 
     export forgit_add="${forgit_add:-ga}"
+    export forgit_unstage="${forgit_unstage:-gu}"
     export forgit_reset_head="${forgit_reset_head:-grh}"
     export forgit_log="${forgit_log:-glo}"
     export forgit_reflog="${forgit_reflog:-grl}"
@@ -172,6 +177,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     export forgit_blame="${forgit_blame:-gbl}"
 
     alias "${forgit_add}"='forgit::add'
+    alias "${forgit_unstage}"='forgit::unstage'
     alias "${forgit_reset_head}"='forgit::reset::head'
     alias "${forgit_log}"='forgit::log'
     alias "${forgit_reflog}"='forgit::reflog'


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Added an "unstage" command that is an alias for git reset (soft) to reverse the effect of staging. Closely follows functionality (and logic) of `git add` implementation.
Documentation change is left TBD because I don't have the same CLI as the other screenshots in README.
Attempted to provide the same additions to zsh and fish, but I can't be sure they work because I don't use those shells.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
