### PR TITLE
Fix: create branch when checking non origin remote

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -849,10 +849,10 @@ _forgit_checkout_branch() {
     [[ -z "$branch" ]] && return 1
 
     # track the remote branch if possible
-    if [[ "$branch" == "remotes/origin/"* ]]; then
-        if git branch | grep -qw "${branch#remotes/origin/}"; then
+    if [[ "$branch" == "remotes/"* ]]; then
+        if git branch | grep -qw "${branch#remotes/*/}"; then
             # hack to force creating a new branch which tracks the remote if a local branch already exists
-            _forgit_git_checkout_branch -b "track/${branch#remotes/origin/}" --track "$branch"
+            _forgit_git_checkout_branch -b "track/${branch#remotes/*/}" --track "$branch"
         elif ! _forgit_git_checkout_branch --track "$branch" 2>/dev/null; then
             _forgit_git_checkout_branch "$branch"
         fi


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

When using `_forgit_checkout_branch` we currently only create a local branch when the remote of the branch is called `origin`. I often work with multiple remotes and also need to push commits to 
remotes other than `origin`. I do not see any harm in creating a local branch when the remote branch is not coming from `origin` (please correct me if I'm wrong). To allow this, this PR is
introducing wildcards to the corresponding checks instead of specifically checking for `origin`.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
