### PR TITLE
feat(fix): Fish shell git ignore and git attributes are maped to same abbreviation

### DIFF
--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -39,7 +39,7 @@ if test -z "$FORGIT_NO_ALIASES"
     abbr -a -- (string collect $forgit_diff; or string collect "gd") git-forgit diff
     abbr -a -- (string collect $forgit_show; or string collect "gso") git-forgit show
     abbr -a -- (string collect $forgit_ignore; or string collect "gi") git-forgit ignore
-    abbr -a -- (string collect $forgit_attributes; or string collect "gi") git-forgit attributes
+    abbr -a -- (string collect $forgit_attributes; or string collect "gai") git-forgit attributes
     abbr -a -- (string collect $forgit_checkout_file; or string collect "gcf") git-forgit checkout_file
     abbr -a -- (string collect $forgit_checkout_branch; or string collect "gcb") git-forgit checkout_branch
     abbr -a -- (string collect $forgit_branch_delete; or string collect "gbd") git-forgit branch_delete

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -39,7 +39,7 @@ if test -z "$FORGIT_NO_ALIASES"
     abbr -a -- (string collect $forgit_diff; or string collect "gd") git-forgit diff
     abbr -a -- (string collect $forgit_show; or string collect "gso") git-forgit show
     abbr -a -- (string collect $forgit_ignore; or string collect "gi") git-forgit ignore
-    abbr -a -- (string collect $forgit_attributes; or string collect "gai") git-forgit attributes
+    abbr -a -- (string collect $forgit_attributes; or string collect "gat") git-forgit attributes
     abbr -a -- (string collect $forgit_checkout_file; or string collect "gcf") git-forgit checkout_file
     abbr -a -- (string collect $forgit_checkout_branch; or string collect "gcb") git-forgit checkout_branch
     abbr -a -- (string collect $forgit_branch_delete; or string collect "gbd") git-forgit branch_delete


### PR DESCRIPTION
<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Description
In fish shell, `git-forgit ignore` and `git-forgit attributes` maped to the same abbreviation `gi`. This pr changes the behavior as default on bash , zsh where `git-forgit ignore` is `gi` and `git-forgit attributes` is `gat`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [x] fish
- OS
    - [x] Linux
    - [x] Mac OS X
    - [x] Windows
    - [x] Others:
