### PR TITLE
Meta: use latest ubuntu image for ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-latest, ubuntu-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

GitHub has deprecated the `ubuntu-20.04` runnner as outlined [here](https://github.com/actions/runner-images/issues/11101). This PR updates the CI to always include the latest available Ubuntu image (currently `ubuntu-24.04`) and removes `ubuntu-20.04`.

We should probably merge this PR before anything else, to prevent the CI from failing when merging new PRs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change
- [X] CI

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
