### PR TITLE
Feature: add interactive squash selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Then add the following to your shell's config file:
 
 - **Interactive `git commit --fixup && git rebase -i --autosquash` selector** (`gfu`)
 
+- **Interactive `git commit --squash && git rebase -i --autosquash` selector** (`gsq`)
+
 # ⌨ Keybindings
 
 | Key                                           | Action                                      |
@@ -205,6 +207,7 @@ forgit_cherry_pick=gcp
 forgit_rebase=grb
 forgit_blame=gbl
 forgit_fixup=gfu
+forgit_squash=gsq
 ```
 
 ## git integration
@@ -263,6 +266,7 @@ These are passed to the according `git` calls.
 | `grb`    | `FORGIT_REBASE_GIT_OPTS`                                                    |
 | `gbl`    | `FORGIT_BLAME_GIT_OPTS`                                                     |
 | `gfu`    | `FORGIT_FIXUP_GIT_OPTS`                                                     |
+| `gsq`    | `FORGIT_SQUASH_GIT_OPTS`                                                    |
 | `gcp`    | `FORGIT_CHERRY_PICK_GIT_OPTS`                                               |
 
 ## pagers
@@ -320,6 +324,7 @@ Customizing fzf options for each command individually is also supported:
 | `grb`    | `FORGIT_REBASE_FZF_OPTS`          |
 | `gbl`    | `FORGIT_BLAME_FZF_OPTS`           |
 | `gfu`    | `FORGIT_FIXUP_FZF_OPTS`           |
+| `gsq`    | `FORGIT_SQUASH_FZF_OPTS`          |
 | `gcp`    | `FORGIT_CHERRY_PICK_FZF_OPTS`     |
 
 Complete loading order of fzf options is:

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -759,25 +759,39 @@ _forgit_file_preview() {
 _forgit_fixup() {
     _forgit_inside_work_tree || return 1
     git diff --cached --quiet && echo 'Nothing to fixup: there are no staged changes.' && return 1
-    local opts graph quoted_files target_commit prev_commit
+    _forgit_edit_commit --fixup "$FORGIT_FIXUP_FZF_OPTS" "$FORGIT_FIXUP_GIT_OPTS" "$@"
+}
+
+_forgit_squash() {
+    _forgit_inside_work_tree || return 1
+    git diff --cached --quiet && echo 'Nothing to squash: there are no staged changes.' && return 1
+    _forgit_edit_commit --squash "$FORGIT_SQUASH_FZF_OPTS" "$FORGIT_SQUASH_GIT_OPTS" "$@"
+}
+
+_forgit_edit_commit() {
+    local action fzf_opts opts graph quoted_files target_commit prev_commit
+    action=$1
+    fzf_opts=$2
     graph=()
     [[ $_forgit_log_graph_enable == true ]] && graph=(--graph)
-    _forgit_fixup_git_opts=()
-    _forgit_parse_array _forgit_fixup_git_opts "$FORGIT_FIXUP_GIT_OPTS"
+    git_opts=()
+    _forgit_parse_array git_opts "$3"
+    shift 3
     quoted_files=$(_forgit_quote_files "$@")
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
         --bind=\"ctrl-y:execute-silent($FORGIT yank_sha {})\"
         --preview=\"$FORGIT file_preview {} $quoted_files\"
-        $FORGIT_FIXUP_FZF_OPTS
+        $fzf_opts
     "
     target_commit=$(
         git log "${graph[@]}" --color=always --format="$_forgit_log_format" "$@" |
         _forgit_emojify |
         FZF_DEFAULT_OPTS="$opts" fzf |
         _forgit_extract_sha)
-    if [[ -n "$target_commit" ]] && git commit "${_forgit_fixup_git_opts[@]}" --fixup "$target_commit"; then
+    # GIT_EDITOR=: is needed to skip the editor
+    if [[ -n "$target_commit" ]] && GIT_EDITOR=: git commit "${git_opts[@]}" "$action" "$target_commit"; then
         prev_commit=$(_forgit_previous_commit "$target_commit")
         # rebase will fail if there are unstaged changes so --autostash is needed to temporarily stash them
         # GIT_SEQUENCE_EDITOR=: is needed to skip the editor
@@ -1152,6 +1166,7 @@ public_commands=(
     "clean"
     "diff"
     "fixup"
+    "squash"
     "ignore"
     "log"
     "reflog"

--- a/completions/_git-forgit
+++ b/completions/_git-forgit
@@ -75,6 +75,7 @@ _git-forgit() {
             'rebase:git rebase'
             'reset_head:git reset HEAD (unstage) selector'
             'revert_commit:git revert commit selector'
+            'squash:git squash'
             'stash_show:git stash viewer'
             'stash_push:git stash push selector'
         )
@@ -96,6 +97,7 @@ _git-forgit() {
     rebase) _git-rebase ;;
     reset_head) _git-staged ;;
     revert_commit) __git_recent_commits ;;
+    squash) __git_branch_names ;;
     stash_show) _git-stash-show ;;
     show) _git-show ;;
     esac
@@ -122,6 +124,7 @@ compdef _git-reflog forgit::reflog
 compdef _git-rebase forgit::rebase
 compdef _git-staged forgit::reset::head
 compdef __git_recent_commits forgit::revert::commit
+compdef __git_branch_names forgit::squash
 compdef _git-stash-show forgit::stash::show
 compdef _git-show forgit::show
 

--- a/completions/git-forgit.bash
+++ b/completions/git-forgit.bash
@@ -76,6 +76,7 @@ _git_forgit()
         reset_head
         revert_commit
         show
+        squash
         stash_show
         stash_push
     "
@@ -103,6 +104,7 @@ _git_forgit()
                 reset_head) _git_reset ;;
                 revert_commit) _git_revert ;;
                 show) _git_show ;;
+                squash) _git_branch ;;
                 stash_show) _git_stash_show ;;
             esac
             ;;
@@ -138,6 +140,7 @@ then
     __git_complete forgit::reset::head _git_reset
     __git_complete forgit::revert::commit _git_revert
     __git_complete forgit::show _git_show
+    __git_complete forgit::squash _git_branch
     __git_complete forgit::stash::show _git_stash_show
 
     # Completion for forgit plugin shell aliases
@@ -158,6 +161,7 @@ then
         __git_complete "${forgit_reset_head}" _git_reset
         __git_complete "${forgit_revert_commit}" _git_revert
         __git_complete "${forgit_show}" _git_show
+        __git_complete "${forgit_squash}" _git_branch
         __git_complete "${forgit_stash_show}" _git_stash_show
     fi
 fi

--- a/completions/git-forgit.fish
+++ b/completions/git-forgit.fish
@@ -8,7 +8,7 @@
 function __fish_forgit_needs_subcommand
     for subcmd in add blame branch_delete checkout_branch checkout_commit checkout_file checkout_tag \
         cherry_pick cherry_pick_from_branch clean diff fixup ignore log reflog rebase reset_head \
-        revert_commit stash_show stash_push
+        revert_commit squash stash_show stash_push
         if contains -- $subcmd (commandline -opc)
             return 1
         end
@@ -41,6 +41,7 @@ complete -c git-forgit -n __fish_forgit_needs_subcommand -a rebase -d 'git rebas
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a reset_head -d 'git reset HEAD (unstage) selector'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a revert_commit -d 'git revert commit selector'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a show -d 'git show viewer'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a squash -d 'git squash'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a stash_show -d 'git stash viewer'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a stash_push -d 'git stash push selector'
 
@@ -60,5 +61,6 @@ complete -c git-forgit -n '__fish_seen_subcommand_from rebase' -a "(complete -C 
 complete -c git-forgit -n '__fish_seen_subcommand_from reset_head' -a "(__fish_git_files all-staged)"
 complete -c git-forgit -n '__fish_seen_subcommand_from revert_commit' -a "(__fish_git_commits)"
 complete -c git-forgit -n '__fish_seen_subcommand_from show' -a "(complete -C 'git show ')"
+complete -c git-forgit -n '__fish_seen_subcommand_from squash' -a "(__fish_git_local_branches)"
 complete -c git-forgit -n '__fish_seen_subcommand_from stash_show' -a "(__fish_git_complete_stashes)"
 complete -c git-forgit -n '__fish_seen_subcommand_from stash_push' -a "(__fish_git_files modified deleted modified-staged-deleted)"

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -49,6 +49,7 @@ if test -z "$FORGIT_NO_ALIASES"
     abbr -a -- (string collect $forgit_cherry_pick; or string collect "gcp") git-forgit cherry_pick_from_branch
     abbr -a -- (string collect $forgit_rebase; or string collect "grb") git-forgit rebase
     abbr -a -- (string collect $forgit_fixup; or string collect "gfu") git-forgit fixup
+    abbr -a -- (string collect $forgit_squash; or string collect "gsq") git-forgit squash
     abbr -a -- (string collect $forgit_checkout_commit; or string collect "gco") git-forgit checkout_commit
     abbr -a -- (string collect $forgit_revert_commit; or string collect "grc") git-forgit revert_commit
     abbr -a -- (string collect $forgit_blame; or string collect "gbl") git-forgit blame

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -96,6 +96,10 @@ forgit::fixup() {
     "$FORGIT" fixup "$@"
 }
 
+forgit::squash() {
+    "$FORGIT" squash "$@"
+}
+
 forgit::checkout::file() {
     "$FORGIT" checkout_file "$@"
 }
@@ -172,6 +176,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     builtin export forgit_cherry_pick="${forgit_cherry_pick:-gcp}"
     builtin export forgit_rebase="${forgit_rebase:-grb}"
     builtin export forgit_fixup="${forgit_fixup:-gfu}"
+    builtin export forgit_squash="${forgit_squash:-gsq}"
     builtin export forgit_blame="${forgit_blame:-gbl}"
 
     builtin alias "${forgit_add}"='forgit::add'
@@ -194,6 +199,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     builtin alias "${forgit_cherry_pick}"='forgit::cherry::pick::from::branch'
     builtin alias "${forgit_rebase}"='forgit::rebase'
     builtin alias "${forgit_fixup}"='forgit::fixup'
+    builtin alias "${forgit_squash}"='forgit::squash'
     builtin alias "${forgit_blame}"='forgit::blame'
 
 fi


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Adds a function for interactive `git commit --squash && git rebase -i --autosquash`. Because this feature is very similar to the existing `_forgit_fixup` function we already have, I moved most of the code from `_forgit_fixup` to  a `_forgit_edit_commit` function, that can be used for both cases.
Closes #438

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
