### PR TITLE
Refactor: Do not pass files to fixup and squash

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -759,34 +759,32 @@ _forgit_file_preview() {
 _forgit_fixup() {
     _forgit_inside_work_tree || return 1
     git diff --cached --quiet && echo 'Nothing to fixup: there are no staged changes.' && return 1
-    _forgit_edit_commit --fixup "$FORGIT_FIXUP_FZF_OPTS" "$FORGIT_FIXUP_GIT_OPTS" "$@"
+    _forgit_edit_commit --fixup "$FORGIT_FIXUP_FZF_OPTS" "$FORGIT_FIXUP_GIT_OPTS"
 }
 
 _forgit_squash() {
     _forgit_inside_work_tree || return 1
     git diff --cached --quiet && echo 'Nothing to squash: there are no staged changes.' && return 1
-    _forgit_edit_commit --squash "$FORGIT_SQUASH_FZF_OPTS" "$FORGIT_SQUASH_GIT_OPTS" "$@"
+    _forgit_edit_commit --squash "$FORGIT_SQUASH_FZF_OPTS" "$FORGIT_SQUASH_GIT_OPTS"
 }
 
 _forgit_edit_commit() {
-    local action fzf_opts opts graph quoted_files target_commit prev_commit
+    local action fzf_opts opts graph target_commit prev_commit
     action=$1
     fzf_opts=$2
     graph=()
     [[ $_forgit_log_graph_enable == true ]] && graph=(--graph)
     git_opts=()
     _forgit_parse_array git_opts "$3"
-    shift 3
-    quoted_files=$(_forgit_quote_files "$@")
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
         --bind=\"ctrl-y:execute-silent($FORGIT yank_sha {})\"
-        --preview=\"$FORGIT file_preview {} $quoted_files\"
+        --preview=\"$FORGIT file_preview {}\"
         $fzf_opts
     "
     target_commit=$(
-        git log "${graph[@]}" --color=always --format="$_forgit_log_format" "$@" |
+        git log "${graph[@]}" --color=always --format="$_forgit_log_format" |
         _forgit_emojify |
         FZF_DEFAULT_OPTS="$opts" fzf |
         _forgit_extract_sha)


### PR DESCRIPTION
Similar to #422, this removes the option to pass files to the fixup and squash functions. I don't think this serves any purpose there either and was simply a copy/paste error too.

## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
