### PR TITLE
Feature: add interactive reword selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Then add the following to your shell's config file:
 
 - **Interactive `git commit --squash && git rebase -i --autosquash` selector** (`gsq`)
 
+- **Interactive `git commit --fixup=reword && git rebase -i --autosquash` selector** (`grw`)
+
 # ⌨ Keybindings
 
 | Key                                           | Action                                      |
@@ -208,6 +210,7 @@ forgit_rebase=grb
 forgit_blame=gbl
 forgit_fixup=gfu
 forgit_squash=gsq
+forgit_reword=grw
 ```
 
 ## git integration
@@ -267,6 +270,7 @@ These are passed to the according `git` calls.
 | `gbl`    | `FORGIT_BLAME_GIT_OPTS`                                                     |
 | `gfu`    | `FORGIT_FIXUP_GIT_OPTS`                                                     |
 | `gsq`    | `FORGIT_SQUASH_GIT_OPTS`                                                    |
+| `grw`    | `FORGIT_REWORD_GIT_OPTS`                                                    |
 | `gcp`    | `FORGIT_CHERRY_PICK_GIT_OPTS`                                               |
 
 ## pagers
@@ -325,6 +329,7 @@ Customizing fzf options for each command individually is also supported:
 | `gbl`    | `FORGIT_BLAME_FZF_OPTS`           |
 | `gfu`    | `FORGIT_FIXUP_FZF_OPTS`           |
 | `gsq`    | `FORGIT_SQUASH_FZF_OPTS`          |
+| `grw`    | `FORGIT_REWORD_FZF_OPTS`          |
 | `gcp`    | `FORGIT_CHERRY_PICK_FZF_OPTS`     |
 
 Complete loading order of fzf options is:

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -799,6 +799,33 @@ _forgit_edit_commit() {
     fi
 }
 
+_forgit_reword() {
+    _forgit_inside_work_tree || return 1
+    local opts graph quoted_files target_commit prev_commit
+    graph=()
+    [[ $_forgit_log_graph_enable == true ]] && graph=(--graph)
+    git_opts=()
+    _forgit_parse_array _forgit_reword_git_opts "$FORGIT_REWORD_GIT_OPTS"
+    opts="
+        $FORGIT_FZF_DEFAULT_OPTS
+        +s +m --tiebreak=index
+        --bind=\"ctrl-y:execute-silent($FORGIT yank_sha {})\"
+        --preview=\"$FORGIT file_preview {}\"
+        $FORGIT_REWORD_FZF_OPTS
+    "
+    target_commit=$(
+        git log "${graph[@]}" --color=always --format="$_forgit_log_format" |
+        _forgit_emojify |
+        FZF_DEFAULT_OPTS="$opts" fzf |
+        _forgit_extract_sha)
+    if [[ -n "$target_commit" ]] && git commit "${git_opts[@]}" --fixup=reword:"$target_commit"; then
+        prev_commit=$(_forgit_previous_commit "$target_commit")
+        # rebase will fail if there are unstaged changes so --autostash is needed to temporarily stash them
+        # GIT_SEQUENCE_EDITOR=: is needed to skip the editor
+        GIT_SEQUENCE_EDITOR=: git rebase --autostash -i --autosquash "$prev_commit"
+    fi
+}
+
 _forgit_checkout_file_preview() {
     git diff --color=always -- "$1" | _forgit_pager diff
 }
@@ -1167,6 +1194,7 @@ public_commands=(
     "diff"
     "fixup"
     "squash"
+    "reword"
     "ignore"
     "log"
     "reflog"

--- a/completions/_git-forgit
+++ b/completions/_git-forgit
@@ -75,6 +75,7 @@ _git-forgit() {
             'rebase:git rebase'
             'reset_head:git reset HEAD (unstage) selector'
             'revert_commit:git revert commit selector'
+            'reword:git fixup=reword'
             'squash:git squash'
             'stash_show:git stash viewer'
             'stash_push:git stash push selector'
@@ -97,6 +98,7 @@ _git-forgit() {
     rebase) _git-rebase ;;
     reset_head) _git-staged ;;
     revert_commit) __git_recent_commits ;;
+    reword) __git_branch_names ;;
     squash) __git_branch_names ;;
     stash_show) _git-stash-show ;;
     show) _git-show ;;
@@ -124,6 +126,7 @@ compdef _git-reflog forgit::reflog
 compdef _git-rebase forgit::rebase
 compdef _git-staged forgit::reset::head
 compdef __git_recent_commits forgit::revert::commit
+compdef __git_branch_names forgit::reword
 compdef __git_branch_names forgit::squash
 compdef _git-stash-show forgit::stash::show
 compdef _git-show forgit::show

--- a/completions/git-forgit.bash
+++ b/completions/git-forgit.bash
@@ -75,6 +75,7 @@ _git_forgit()
         rebase
         reset_head
         revert_commit
+        reword
         show
         squash
         stash_show
@@ -103,6 +104,7 @@ _git_forgit()
                 rebase) _git_rebase ;;
                 reset_head) _git_reset ;;
                 revert_commit) _git_revert ;;
+                reword) _git_branch ;;
                 show) _git_show ;;
                 squash) _git_branch ;;
                 stash_show) _git_stash_show ;;
@@ -139,6 +141,7 @@ then
     __git_complete forgit::rebase _git_rebase
     __git_complete forgit::reset::head _git_reset
     __git_complete forgit::revert::commit _git_revert
+    __git_complete forgit::reword _git_branch
     __git_complete forgit::show _git_show
     __git_complete forgit::squash _git_branch
     __git_complete forgit::stash::show _git_stash_show
@@ -160,6 +163,7 @@ then
         __git_complete "${forgit_rebase}" _git_rebase
         __git_complete "${forgit_reset_head}" _git_reset
         __git_complete "${forgit_revert_commit}" _git_revert
+        __git_complete "${forgit_reword_commit}" _git_branch
         __git_complete "${forgit_show}" _git_show
         __git_complete "${forgit_squash}" _git_branch
         __git_complete "${forgit_stash_show}" _git_stash_show

--- a/completions/git-forgit.fish
+++ b/completions/git-forgit.fish
@@ -8,7 +8,7 @@
 function __fish_forgit_needs_subcommand
     for subcmd in add blame branch_delete checkout_branch checkout_commit checkout_file checkout_tag \
         cherry_pick cherry_pick_from_branch clean diff fixup ignore log reflog rebase reset_head \
-        revert_commit squash stash_show stash_push
+        revert_commit reword squash stash_show stash_push
         if contains -- $subcmd (commandline -opc)
             return 1
         end
@@ -40,6 +40,7 @@ complete -c git-forgit -n __fish_forgit_needs_subcommand -a reflog -d 'git reflo
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a rebase -d 'git rebase'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a reset_head -d 'git reset HEAD (unstage) selector'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a revert_commit -d 'git revert commit selector'
+complete -c git-forgit -n __fish_forgit_needs_subcommand -a reword -d 'git fixup=reword'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a show -d 'git show viewer'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a squash -d 'git squash'
 complete -c git-forgit -n __fish_forgit_needs_subcommand -a stash_show -d 'git stash viewer'
@@ -60,6 +61,7 @@ complete -c git-forgit -n '__fish_seen_subcommand_from reflog' -a "(complete -C 
 complete -c git-forgit -n '__fish_seen_subcommand_from rebase' -a "(complete -C 'git rebase ')"
 complete -c git-forgit -n '__fish_seen_subcommand_from reset_head' -a "(__fish_git_files all-staged)"
 complete -c git-forgit -n '__fish_seen_subcommand_from revert_commit' -a "(__fish_git_commits)"
+complete -c git-forgit -n '__fish_seen_subcommand_from reword' -a "(__fish_git_local_branches)"
 complete -c git-forgit -n '__fish_seen_subcommand_from show' -a "(complete -C 'git show ')"
 complete -c git-forgit -n '__fish_seen_subcommand_from squash' -a "(__fish_git_local_branches)"
 complete -c git-forgit -n '__fish_seen_subcommand_from stash_show' -a "(__fish_git_complete_stashes)"

--- a/conf.d/forgit.plugin.fish
+++ b/conf.d/forgit.plugin.fish
@@ -50,6 +50,7 @@ if test -z "$FORGIT_NO_ALIASES"
     abbr -a -- (string collect $forgit_rebase; or string collect "grb") git-forgit rebase
     abbr -a -- (string collect $forgit_fixup; or string collect "gfu") git-forgit fixup
     abbr -a -- (string collect $forgit_squash; or string collect "gsq") git-forgit squash
+    abbr -a -- (string collect $forgit_reword; or string collect "grw") git-forgit reword
     abbr -a -- (string collect $forgit_checkout_commit; or string collect "gco") git-forgit checkout_commit
     abbr -a -- (string collect $forgit_revert_commit; or string collect "grc") git-forgit revert_commit
     abbr -a -- (string collect $forgit_blame; or string collect "gbl") git-forgit blame

--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -100,6 +100,10 @@ forgit::squash() {
     "$FORGIT" squash "$@"
 }
 
+forgit::reword() {
+    "$FORGIT" reword "$@"
+}
+
 forgit::checkout::file() {
     "$FORGIT" checkout_file "$@"
 }
@@ -177,6 +181,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     builtin export forgit_rebase="${forgit_rebase:-grb}"
     builtin export forgit_fixup="${forgit_fixup:-gfu}"
     builtin export forgit_squash="${forgit_squash:-gsq}"
+    builtin export forgit_reword="${forgit_reword:-grw}"
     builtin export forgit_blame="${forgit_blame:-gbl}"
 
     builtin alias "${forgit_add}"='forgit::add'
@@ -200,6 +205,7 @@ if [[ -z "$FORGIT_NO_ALIASES" ]]; then
     builtin alias "${forgit_rebase}"='forgit::rebase'
     builtin alias "${forgit_fixup}"='forgit::fixup'
     builtin alias "${forgit_squash}"='forgit::squash'
+    builtin alias "${forgit_reword}"='forgit::reword'
     builtin alias "${forgit_blame}"='forgit::blame'
 
 fi


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation

## Description

Because we allow editing commits with (squash) and without (fixup) editing the commit message, it makes sense to me to also **only** edit the message of a commit, which is something I do regularly. `git commit` has the `--fixup=reword:<COMMIT>` option that I make use of here. Unfortunately, this implementation cannot share the `_forgit_edit_commit` function that we use for fixup and squash because the syntax with reword is a bit different:

1. With reword, git expects `--fixup=reword:<COMMIT>` whereas with fixup and squash, it does not expect the colon.
2. With reword, we do not want to skip the editor when creating the commit.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [X] bash
    - [X] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
