### PR TITLE
Refactor: do not disable shellcheck 2230

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -28,10 +28,6 @@ if [[ "$higher_fzf_version" != "$installed_fzf_version" ]]; then
 fi
 
 # Set shell for fzf preview commands
-# Disable shellcheck for "which", because it suggests "command -v xxx" instead,
-# which is not a working replacement.
-# See https://github.com/koalaman/shellcheck/issues/1162
-# shellcheck disable=2230
 SHELL="$(which bash)"
 export SHELL
 


### PR DESCRIPTION

## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Shellcheck 2230 has been made optional and disabled by default. Ubuntu 24.04 (which we now use exclusively for our Linux CI) already has this change. For details see https://www.shellcheck.net/wiki/SC2230.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
