### PR TITLE
Feat: Use forgit show in stash_show enter

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -525,24 +525,26 @@ _forgit_reset_head() {
 
 _forgit_stash_show_preview() {
     local stash
-    stash=$(echo "$1" | cut -d: -f1)
-    _forgit_git_stash_show "$stash" | _forgit_pager diff
+    stash=$(echo "$1" | _forgit_extract_stash_name)
+    echo "$stash" | xargs -I% git show --color=always -U"$_forgit_preview_context" % | _forgit_pager show
 }
 
-_forgit_git_stash_show() {
-    git stash show --color=always --ext-diff "$@"
+_forgit_stash_show_enter() {
+    local stash
+    stash=$(echo "$1" | _forgit_extract_stash_name)
+    echo "$stash" | xargs -I% "${FORGIT}" show %
 }
 
 # git stash viewer
 _forgit_stash_show() {
     _forgit_inside_work_tree || return 1
     local opts
-    [[ $# -ne 0 ]] && { _forgit_git_stash_show "$@"; return $?; }
+    [[ $# -ne 0 ]] && { "${FORGIT}" show "$@"; return $?; }
     _forgit_stash_show_git_opts=()
     _forgit_parse_array _forgit_stash_show_git_opts "$FORGIT_STASH_SHOW_GIT_OPTS"
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
-        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_preview {} | $FORGIT pager enter)\"
+        +s +m -0 --tiebreak=index --bind=\"enter:execute($FORGIT stash_show_enter {})\"
         --bind=\"ctrl-y:execute-silent($FORGIT yank_stash_name {})\"
         --preview=\"$FORGIT stash_show_preview {}\"
         $FORGIT_STASH_FZF_OPTS
@@ -1106,7 +1108,7 @@ _forgit_ignore() {
         args=()
         while IFS='' read -r arg; do
             args+=("$arg")
-        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore | 
+        done < <(_forgit_paths_list "$FORGIT_GI_TEMPLATES" .gitignore |
             nl -w4 -s'  ' |
             FZF_DEFAULT_OPTS="$opts" fzf | awk '{print $2}')
     fi
@@ -1221,6 +1223,7 @@ private_commands=(
     "show_enter"
     "show_preview"
     "stash_push_preview"
+    "stash_show_enter"
     "stash_show_preview"
     "yank_sha"
     "yank_stash_name"

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -190,14 +190,14 @@ _forgit_log_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always -U"$_forgit_preview_context" % -- "$@" | _forgit_pager show
+    git show --color=always -U"$_forgit_preview_context" "${sha}" -- "$@" | _forgit_pager show
 }
 
 _forgit_log_enter() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% "${FORGIT}" show % "$@"
+    "${FORGIT}" show "${sha}" "$@"
 }
 
 # git commit viewer
@@ -526,13 +526,13 @@ _forgit_reset_head() {
 _forgit_stash_show_preview() {
     local stash
     stash=$(echo "$1" | _forgit_extract_stash_name)
-    echo "$stash" | xargs -I% git show --color=always -U"$_forgit_preview_context" % | _forgit_pager show
+    git show --color=always -U"$_forgit_preview_context" "${stash}" | _forgit_pager show
 }
 
 _forgit_stash_show_enter() {
     local stash
     stash=$(echo "$1" | _forgit_extract_stash_name)
-    echo "$stash" | xargs -I% "${FORGIT}" show %
+    "${FORGIT}" show "${stash}"
 }
 
 # git stash viewer
@@ -635,7 +635,9 @@ _forgit_clean() {
 }
 
 _forgit_cherry_pick_preview() {
-    echo "$1" | cut -f2- | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_pager show
+    local sha
+    sha=$(echo "$1" | cut -f2- | _forgit_extract_sha)
+    git show --color=always "${sha}" | _forgit_pager show
 }
 
 _forgit_cherry_pick() {
@@ -751,7 +753,7 @@ _forgit_file_preview() {
     local sha
     sha=$(echo "$1" | _forgit_extract_sha)
     shift
-    echo "$sha" | xargs -I% git show --color=always % -- "$@" | _forgit_pager show
+    git show --color=always "${sha}" -- "$@" | _forgit_pager show
 }
 
 _forgit_fixup() {
@@ -924,7 +926,9 @@ _forgit_checkout_tag() {
 }
 
 _forgit_checkout_commit_preview() {
-    echo "$1" | _forgit_extract_sha | xargs -I% git show --color=always % | _forgit_pager show
+    local sha
+    sha=$(echo "$1" | _forgit_extract_sha)
+    git show --color=always "${sha}" | _forgit_pager show
 }
 
 _forgit_git_checkout_commit() {
@@ -987,11 +991,9 @@ _forgit_branch_delete() {
 }
 
 _forgit_revert_preview() {
-    echo "$1" |
-    cut -f2- |
-    _forgit_extract_sha |
-    xargs -I% git show --color=always % |
-    _forgit_pager show
+    local sha
+    sha=$(echo "$1" | cut -f2- | _forgit_extract_sha)
+    git show --color=always "${sha}" | _forgit_pager show
 }
 
 _forgit_git_revert() {


### PR DESCRIPTION
Instead of using `git stash show` in the `enter` binding of the `stash_show` command, use `forgit show`. This allows forgit to show the stash in the same interactive way it shows other commits (e.g. on `forgit log`), with the same context and formatting options.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
