### PR TITLE
Feat: allow passing arguments to git add

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -462,7 +462,7 @@ _forgit_add() {
     _forgit_inside_work_tree || return 1
     local changed unmerged untracked files opts
     # Add files if passed as arguments
-    [[ $# -ne 0 ]] && { _forgit_git_add "$@" && git status -s; return $?; }
+    _forgit_contains_non_flags "$@" && { _forgit_git_add "$@" && git status -s; return $?; }
 
     changed=$(git config --get-color color.status.changed red)
     unmerged=$(git config --get-color color.status.unmerged red)
@@ -482,7 +482,7 @@ _forgit_add() {
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf |
         _forgit_get_single_file_from_add_line)
-    [[ "${#files[@]}" -gt 0 ]] && _forgit_git_add "${files[@]}" && git status -s && return
+    [[ "${#files[@]}" -gt 0 ]] && _forgit_git_add "$@" "${files[@]}" && git status -s && return
     echo 'Nothing to add.'
 }
 


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Pretty much the same as #451 but for `git add`. Allows e.g., staging only part of a file with `ga -p`.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
