### PR TITLE
Fix: remove explicit -u flag in git status command in _forgit_add

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -477,7 +477,7 @@ _forgit_add() {
     files=()
     while IFS='' read -r file; do
         files+=("$file")
-    done < <(git -c color.status=always -c status.relativePaths=true -c core.quotePath=false status -su |
+    done < <(git -c color.status=always -c status.relativePaths=true -c core.quotePath=false status -s |
         grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf |


### PR DESCRIPTION

## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

`git status` includes untracked files by default, so passing the flag explicitly is not necessary. This allows overriding forgits behavior by setting `showUntrackedFiles = no` in the .gitconfig.

Fixes #449

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
