### PR TITLE
Fix: early out with non file arguments in checkout file

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -841,7 +841,7 @@ _forgit_git_checkout_file() {
 _forgit_checkout_file() {
     _forgit_inside_work_tree || return 1
     local files opts
-    _forgit_contains_non_flags "$@" && { _forgit_git_checkout_file -- "$@"; return $?; }
+    _forgit_contains_non_flags "$@" && { _forgit_git_checkout_file "$@"; return $?; }
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

Removes the end of option marker (`--`) passed to `_forgit_checkout_file` when returning early in `_forgit_checkout_file`. This allows non-file arguments to be used in this case.
This is a follow-up to #451

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
