### PR TITLE
Fix: use github/gitignore for ignore files

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -1078,9 +1078,9 @@ _forgit_blame() {
 }
 
 # git ignore generator
-export FORGIT_GI_REPO_REMOTE=${FORGIT_GI_REPO_REMOTE:-https://github.com/dvcs/gitignore}
-export FORGIT_GI_REPO_LOCAL="${FORGIT_GI_REPO_LOCAL:-${XDG_CACHE_HOME:-$HOME/.cache}/forgit/gi/repos/dvcs/gitignore}"
-export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL/templates}
+export FORGIT_GI_REPO_REMOTE=${FORGIT_GI_REPO_REMOTE:-https://github.com/github/gitignore}
+export FORGIT_GI_REPO_LOCAL="${FORGIT_GI_REPO_LOCAL:-${XDG_CACHE_HOME:-$HOME/.cache}/forgit/gi/repos/github/gitignore}"
+export FORGIT_GI_TEMPLATES=${FORGIT_GI_TEMPLATES:-$FORGIT_GI_REPO_LOCAL}
 
 _forgit_path_preview() {
     local path name ext pager


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

The repository we were using for .gitignore files has been removed or made private. Use [github/gitignore](https://github.com/github/gitignore) instead.

Closes #460

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
