### PR TITLE
Fix: preview for add and clean when file names contain backslashes

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -464,13 +464,11 @@ _forgit_edit_add_file() {
 # git add selector
 _forgit_add() {
     _forgit_inside_work_tree || return 1
-    local changed unmerged untracked files opts show_untracked
+    local added files opts show_untracked
     # Add files if passed as arguments
     _forgit_contains_non_flags "$@" && { _forgit_git_add "$@" && git status -s; return $?; }
 
-    changed=$(git config --get-color color.status.changed red)
-    unmerged=$(git config --get-color color.status.unmerged red)
-    untracked=$(git config --get-color color.status.untracked red)
+    added=$(git config --get-color color.status.added green)
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -0 -m --nth 2..,..
@@ -482,8 +480,9 @@ _forgit_add() {
     show_untracked=$(git config status.showUntrackedFiles)
     while IFS='' read -r file; do
         files+=("$file")
-    done < <(git -c color.status=always -c status.relativePaths=true -c core.quotePath=false status -s --untracked="${show_untracked:-all}" |
-        grep -F -e "$changed" -e "$unmerged" -e "$untracked" |
+    done < <(git -c color.status=always -c status.relativePaths=true status -s -z --untracked="${show_untracked:-all}" |
+        tr '\0' '\n' |
+        grep -F --invert-match "$added" |
         sed -E 's/^(..[^[:space:]]*)[[:space:]]+(.*)$/[\1]  \2/' |
         FZF_DEFAULT_OPTS="$opts" fzf |
         _forgit_get_single_file_from_add_line)
@@ -634,7 +633,7 @@ _forgit_clean() {
         $FORGIT_CLEAN_FZF_OPTS
     "
     # Note: Postfix '/' in directory path should be removed. Otherwise the directory itself will not be removed.
-    files=$(git -c core.quotePath=false clean -xdffn "$@"| sed 's/^Would remove //' | FZF_DEFAULT_OPTS="$opts" fzf |sed 's#/$##')
+    files=$(_forgit_list_files --others "$@" | sed 's/^Would remove //' | FZF_DEFAULT_OPTS="$opts" fzf |sed 's#/$##')
     [[ -n "$files" ]] && echo "$files" | tr '\n' '\0' | xargs -0 -I% git clean "${_forgit_clean_git_opts[@]}" -xdff '%' && git status --short && return
     echo 'Nothing to clean.'
 }


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Description

While playing around with #464, I noticed that the preview of `forgit add` and `forgit clean` do not work with files that have backslashes in their names. The preview just shows something like

> error: Could not access 'file\\.txt'

This is due to the same issue we tried to address with #388 (git escapes special characters in its output, but does not expect them to be escaped when used for input). Since #388 we use the `-z` option with most git commands that have this "issue" to prevent them from escaping their output. In `forgit add` and `forgit clean` we use the `core.quotePath false` config option instead. In `forgit add` because we make use of the colors of the output of `git status` and in `forgit clean` because `git clean` does not have a `-z` option.
I noticed that (in contrast to my previous belief), `-z` does not remove the colors from `git status`, so it can be used in `forgit add`. However, I could not find a way to get things working with our current implementation, but I found a simpler approach to what we're trying to achieve that actually does work. We try to filter out added files using `grep` by matching lines with changed, unmerged and untracked files. Instead we can just do an inverse match for added files.
For `forgit clean` I've modified the command to use `_forgit_list_files` instead of `git clean -n`. This comes with a minor breaking change: flag arguments provided to `forgit clean` are now passed to `git ls-files` instead of `git clean -n`. However, git ls-files is way more flexible than git clean, so all use cases covered by git clean (and more) should still be possible. This will even allow us to introduce an environment variable in the future to modify which files are included when cleaning (I'll explain my use case in another PR, this text is already way too long :wink:).

## Type of change

- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Breaking change
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:
