### PR TITLE
fix: preview of `checkout_file_from_commit` & `worktree_add` commands

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -1596,7 +1596,7 @@ _forgit_worktree_add() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index $header_opt
-        --preview=\"$FORGIT branch_preview {}\"
+        --preview=\"$FORGIT preview branch_preview {}\"
         $FORGIT_WORKTREE_ADD_FZF_OPTS
     "
     branch=$(_forgit_branch_list "${_forgit_worktree_add_branch_git_opts[@]:---all}" |

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -1019,7 +1019,7 @@ _forgit_checkout_file_from_commit() {
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         +s +m --tiebreak=index
-        --preview=\"$FORGIT log_preview {}\"
+        --preview=\"$FORGIT preview log_preview {}\"
         $FORGIT_CHECKOUT_FILE_FROM_COMMIT_LOG_FZF_OPTS
     "
     commit=$(_forgit_git_log "$_forgit_log_format" "$branch" "$@" |


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [ ] I have made corresponding changes to the documentation

## Description

Seems I forgot to update this this preview when I rebased #499 on top of f7e2d436. We did not notice this because this has only become a breaking change after 30aff90.
Without this fix, the preview of `_forgit_checkout_file_from_commit` shows the "forgit: 'log_preview' is not a valid forgit command" message.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preview rendering when inspecting files before checkout or when adding worktrees now uses the unified preview wrapper. This yields more consistent, reliable previews and fixes inconsistencies in how previews were dispatched for those operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->