### PR TITLE
ci: do not install recommended packages when using apt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         elif [[ "${{ matrix.os }}" == ubuntu* ]]; then
           sudo apt-add-repository -y ppa:fish-shell/release-3
           sudo apt -y update
-          sudo apt -y install zsh fish shellcheck
+          sudo apt -y install --no-install-recommends zsh fish shellcheck
         fi
         curl -s https://bashunit.typeddevs.com/install.sh | bash -s 0.31.0
 


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [ ] I have made corresponding changes to the documentation

## Description

Not installing recommended packages should speed up the CI. The speedup is probably very small, but because there is no downside to this I think we should take it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change
- [X] CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline by reducing unnecessary package dependencies, improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->