### PR TITLE
docs: raise required fzf version to 0.60

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ It's **lightweight** and **easy to use**.
 
 ### Requirements
 
-- [`fzf`](https://github.com/junegunn/fzf) version `0.49.0` or higher
+- [`fzf`](https://github.com/junegunn/fzf) version `0.60.0` or higher
 
   If your OS package manager bundles an older version of `fzf`, you might install it using [`fzf`'s own install script](https://github.com/junegunn/fzf?tab=readme-ov-file#using-git).
 


### PR DESCRIPTION
## Check list

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [X] I have made corresponding changes to the documentation

## Description

We require `fzf` 0.60.0+ since #506, but did not mention this in the README.md yet.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [X] Documentation change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the minimum required version for the `fzf` dependency from 0.49.0 to 0.60.0 in the project requirements documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->