### PR TITLE
ci: lint GitHub actions with actionlint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
     - name: Install prerequisites
       shell: bash
       run: |
+        # shellcheck disable=SC2193
         if [[ "${{ matrix.os }}" == macos* ]]; then
           brew install zsh fish shellcheck
         elif [[ "${{ matrix.os }}" == ubuntu* ]]; then
@@ -94,3 +95,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: rvben/rumdl@v0.1.68
+
+  # Lint GitHub Actions workflows
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
             VERSION=$(date +'%y.%m.0')
           fi
           echo "VERSION=$VERSION"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Generate Changelog
         id: changelog
@@ -66,7 +66,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create Package
-        run: tar -czf forgit-${{ needs.changelog.outputs.version }}.tar.gz --exclude LICENSE --exclude README.md --exclude cliff.toml *
+        run: tar -czf forgit-${{ needs.changelog.outputs.version }}.tar.gz --exclude LICENSE --exclude README.md --exclude cliff.toml ./*
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,7 @@ repos:
   rev: v0.1.68
   hooks:
     - id: rumdl-fmt  # Auto-format and fail if issues remain
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.12
+  hooks:
+  - id: actionlint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ To run the same checks as CI, make sure these tools are available locally:
 - `curl`
 - `bashunit` as `lib/bashunit`
 - `rumdl`
+- `actionlint`
 
 If `lib/bashunit` is not available yet, install it once with:
 
@@ -72,6 +73,7 @@ zsh forgit.plugin.zsh
 fish conf.d/forgit.plugin.fish
 shfmt --write .
 rumdl check .
+actionlint
 ```
 
 In your pull request, report which shells and operating systems you tested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,7 @@ To run the same checks as CI, make sure these tools are available locally:
 - `shellcheck`
 - `curl`
 - `bashunit` as `lib/bashunit`
+- `shfmt`
 - `rumdl`
 - `actionlint`
 


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [X] I have made corresponding changes to the documentation

## Description

Add a CI job and pre-commit hook to lint our GitHub actions using [`actionlint`](https://github.com/rhysd/actionlint). Also adds shfmt as developer dependency in CONTRIBUTING.md, which I forgot to do in #514. This should be the final part of my quest to improve our CI.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [X] Documentation change
- [X] CI



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflow validation in CI and a matching pre-commit check to catch workflow issues early.
  * Improved release packaging and build script handling for more reliable artifact creation and artifact metadata emission.
* **Documentation**
  * Updated developer setup and local validation steps to include new tooling (actionlint, shfmt) for consistent local checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->