### PR TITLE
fix: use ERE (-E) for grep to fix POSIX-strict compatibility

### DIFF
--- a/forgit.plugin.zsh
+++ b/forgit.plugin.zsh
@@ -33,7 +33,7 @@ unexported_vars=0
 # Set posix mode in bash to only get variables, see #256.
 [[ -n $BASH_VERSION ]] && builtin set -o posix
 builtin set | command awk -F '=' '{ print $1 }' | command grep FORGIT_ | while builtin read -r var; do
-    if ! builtin export | command grep -q "\(^$var=\|^export $var=\)"; then
+    if ! builtin export | command grep -Eq "(^$var=|^export $var=)"; then
         if [[ $unexported_vars == 0 ]]; then
             forgit::warn "Config options have to be exported in future versions of forgit."
             forgit::warn "Please update your config accordingly:"


### PR DESCRIPTION

## Check list

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [ ] I have made corresponding changes to the documentation

## Description

In environments with strict POSIX compliance, such as OpenBSD, `\(`, `\)` and `\|` are not interpreted as basic regular expressions, so matching the output of the builtin export with variable names always failed, resulting in warnings even for exported variables.
GNU grep (Linux) and macOS grep interpret `\(`, `\)` and `\|` as basic regular expression extensions, so this issue did not surface.

## Changes
The option of `grep` has been changed from `-q` to `-Eq` to use extended regular expressions.
In addition, `\|` has been changed to `|`, `\(` to `(`, and `\)` to `)` respectively.

Following the above changes, I have confirmed that it works correctly on
- macOS (grep (BSD grep, GNU compatible) 2.6.0-FreeBSD)
- Linux (grep (GNU grep) 3.11)
- OpenBSD (grep version 0.9)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [x] Others: OpenBSD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of exported configuration variables using a more robust pattern match to avoid missing declared exports.
  * Reduces false negatives when checking config exports, ensuring missing variables are correctly exported and improving shell plugin reliability.
  * Prevents intermittent failures and makes configuration handling more predictable for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->