### PR TITLE
chore(dependabot): group rumdl action and pre-commit updates and update them only once per month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,42 @@
 version: 2
+
+multi-ecosystem-groups:
+  rumdl:
+      schedule:
+        interval: "monthly"
+      commit-message:
+        prefix: "chore(deps)"
+
 updates:
+    # combine rumdl github action and pre-commit hook in a single PR
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*rumdl*"
+    multi-ecosystem-group: "rumdl"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    patterns:
+      - "*rumdl*"
+    multi-ecosystem-group: "rumdl"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+        # already handled by the rumdl multi-ecosystem-group
+      - dependency-name: "*rumdl*"
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "*rumdl*"
     groups:
       # update all pre-commit hooks in a single PR
       pre-commit:


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [ ] I have made corresponding changes to the documentation

## Description

When I added `rumdl`, I wasn't aware that they do releases every other day. This creates unnecessary churn. Improve this by:

1. Group the `rumdl` pre-commit hook and GitHub action together in a single PR
2. Update `rumdl` only once per month instead of each week

Given that `rumdl` is only used for checks, I think only updating it once per month is enough. Let me know if you think otherwise.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change
- [X] CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to optimize the scheduling and grouping of routine dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->