### PR TITLE
ci: use bashunit GitHub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,10 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v6
+    - uses: TypedDevs/bashunit@v0
+      with:
+          version: '0.40.0'
+          verify-checksum: 'true'
 
     # Runs a single command using the runners shell
     - name: Install prerequisites
@@ -40,7 +44,6 @@ jobs:
           sudo apt -y update
           sudo apt -y install --no-install-recommends zsh fish shellcheck
         fi
-        curl -s https://bashunit.typeddevs.com/install.sh | bash -s 0.31.0
 
     - name: Show version
       run: |
@@ -54,7 +57,7 @@ jobs:
       run: shellcheck forgit.plugin.sh bin/git-forgit
 
     - name: Unit tests
-      run: lib/bashunit .
+      run: bashunit tests
 
     - name: Test bash
       run: bash forgit.plugin.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ To run the same checks as CI, make sure these tools are available locally:
 If `lib/bashunit` is not available yet, install it once with:
 
 ```sh
-curl -s https://bashunit.typeddevs.com/install.sh | bash -s 0.31.0
+curl --silent --fail --location https://bashunit.typeddevs.com/install.sh | bash -s 0.40.0
 ```
 
 Local Validation


### PR DESCRIPTION
## Check list

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [ ] I have made corresponding changes to the documentation

## Description

I noticed that the CI broke due to the bashunit install script being moved and our installation command not following the HTTP 301 redirect, see https://github.com/wfxr/forgit/actions/runs/27641954596/job/81764126377. While fixing it, I noticed that bashunit now has a GitHub action. This comes in pretty handy as it allows dependabot to handle bashunit updates for the CI now.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change
- [X] CI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Chores**
  - Updated the continuous integration workflow to use **BashUnit 0.40.0** and to run the test suite via the standard **`bashunit tests`** command.
- **Documentation**
  - Updated contributing/install instructions to use **BashUnit 0.40.0** and revised the `curl` options for a more reliable download during the `curl | bash` setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->