### PR TITLE
fix: support arbitrary whitespace in _forgit_parse_array

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -100,8 +100,11 @@ _forgit_yank_stash_name() {
 _forgit_parse_array() {
     ${IFS+"false"} && unset old_IFS || old_IFS="$IFS"
     # read the value of the second argument
-    # into an array that has the name of the first argument
-    IFS=" " read -r -a "$1" <<<"$2"
+    # into an array that has the name of the first argument.
+    # Split on any whitespace (spaces, tabs, newlines) and use an empty
+    # delimiter so the whole value is consumed instead of stopping at the
+    # first line; leading/trailing whitespace is ignored.
+    IFS=$' \t\n' read -r -d '' -a "$1" <<<"$2"
     ${old_IFS+"false"} && unset IFS || IFS="$old_IFS"
 }
 

--- a/tests/parse-array.test.sh
+++ b/tests/parse-array.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+function set_up_before_script() {
+    source bin/git-forgit
+}
+
+# Asserts that _forgit_parse_array splits the given input string into exactly
+# the expected elements.
+#
+# Usage: assert_parsed_array <input> [expected_element...]
+#   <input>             the raw string passed to _forgit_parse_array
+#   [expected_element]  zero or more elements the input should split into,
+#                       typically passed by expanding an array: "${expected[@]}"
+function assert_parsed_array() {
+    local -r input="$1"
+    shift
+    local -r expected=("$@")
+    local -a actual=()
+    _forgit_parse_array actual "$input"
+
+    assert_same "${#expected[@]}" "${#actual[@]}"
+
+    local i
+    for i in "${!expected[@]}"; do
+        assert_same "${expected[i]}" "${actual[i]}"
+    done
+}
+
+function test_forgit_parse_array_splits_space_separated_values() {
+    local -r input="--foo --bar"
+    local -r expected=("--foo" "--bar")
+    assert_parsed_array "$input" "${expected[@]}"
+}
+
+function test_forgit_parse_array_keeps_single_value() {
+    local -r input="--force"
+    local -r expected=("--force")
+    assert_parsed_array "$input" "${expected[@]}"
+}
+
+function test_forgit_parse_array_empty_string_yields_no_elements() {
+    local -r input=""
+    local -r expected=()
+    assert_parsed_array "$input" "${expected[@]}"
+}
+
+function test_forgit_parse_array_ignores_surrounding_newlines() {
+    local -r input="
+    --force
+"
+    local -r expected=("--force")
+    assert_parsed_array "$input" "${expected[@]}"
+}
+
+function test_forgit_parse_array_splits_values_across_indented_lines() {
+    local -r input="
+    --foo
+    --bar
+"
+    local -r expected=("--foo" "--bar")
+    assert_parsed_array "$input" "${expected[@]}"
+}
+
+function test_forgit_parse_array_splits_on_tabs() {
+    local -r input=$'\t--foo\t\t--bar\t'
+    local -r expected=("--foo" "--bar")
+    assert_parsed_array "$input" "${expected[@]}"
+}
+
+function test_forgit_parse_array_whitespace_only_yields_no_elements() {
+    local -r input="
+    "
+    local -r expected=()
+    assert_parsed_array "$input" "${expected[@]}"
+}


### PR DESCRIPTION
Config variable values spanning multiple lines were silently dropped: read stopped at the first newline and IFS only split on spaces, so the resulting array came out empty.

Example:

```bash
export FORGIT_WORKTREE_DELETE_GIT_OPTS="
    --force
"
```

This resulted in an empty options array before. This PR fixes this and also adds corresponding unit tests (failing before the fix, now green).

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added unit tests for my code
- [ ] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change
- [ ] CI change

## Test environment

- Shell
    - [x] bash
    - [ ] zsh
    - [ ] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input parsing to correctly handle multiple types of whitespace characters (spaces, tabs, and newlines) when processing command arguments.

* **Tests**
  * Introduced comprehensive test coverage for the parsing functionality, including edge cases such as empty inputs, multi-line values, and whitespace-only strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->