### PR TITLE
ci: update bashunit GitHub action using dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,8 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v7
-    - uses: TypedDevs/bashunit@v0
+    - uses: TypedDevs/bashunit@0.40.0
       with:
-          version: '0.40.0'
           verify-checksum: 'true'
 
     # Runs a single command using the runners shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ To run the same checks as CI, make sure these tools are available locally:
 If `lib/bashunit` is not available yet, install it once with:
 
 ```sh
-curl --silent --fail --location https://bashunit.typeddevs.com/install.sh | bash -s 0.40.0
+curl --silent --fail --location https://bashunit.typeddevs.com/install.sh | bash
 ```
 
 Local Validation


### PR DESCRIPTION
## Description

Now that we use the bashunit GitHub Action and get updates with dependabot, we can always assume to
be on the latest version. This way we don't have to update the docs constantly.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [X] Documentation change
- [x] CI change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to use the testing utility’s upstream installer without pinning a specific version.

* **Chores**
  * Updated continuous integration to invoke the testing utility at version 0.40.0 with checksum verification enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->