### PR TITLE
perf: avoid listing modified files twice in checkout-file

### DIFF
--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -1123,12 +1123,13 @@ _forgit_git_checkout_file() {
 # git checkout-file selector
 _forgit_checkout_file() {
     _forgit_inside_work_tree || return 1
-    local files opts
+    local files opts modified_files
     _forgit_contains_non_flags "$@" && {
         _forgit_git_checkout_file "$@"
         return $?
     }
-    [[ $(_forgit_list_modified_files | wc -l) -eq 0 ]] && echo 'Nothing to checkout.' && return 1
+    modified_files="$(_forgit_list_modified_files)"
+    [[ -z $modified_files ]] && echo 'Nothing to checkout.' && return 1
     opts="
         $FORGIT_FZF_DEFAULT_OPTS
         -m -0
@@ -1138,7 +1139,7 @@ _forgit_checkout_file() {
     files=()
     while IFS='' read -r file; do
         files+=("$file")
-    done < <(_forgit_list_modified_files |
+    done < <(printf '%s\n' "$modified_files" |
         FZF_DEFAULT_OPTS="$opts" fzf)
     [[ ${#files[@]} -gt 0 ]] && _forgit_git_checkout_file "$@" "${files[@]}"
 }


### PR DESCRIPTION
_forgit_checkout_file called _forgit_list_modified_files once to check for an empty result and again to feed fzf, running git diff twice on every invocation. Cache the result and reuse it for both checks.

<!-- NOTE: forgit.plugin.zsh & forgit.plugin.sh share the same code. You should make sure the changes work in both `zsh` & `bash` -->

<!-- Check all that apply [x] -->

## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added unit tests for my code
- [x] I have made corresponding changes to the documentation

## Description

<!-- Please include a summary of the change (and the related issue, if any). Please also include relevant motivation and context when necessary. -->

## Type of change

- [x] Performance

## Test environment

- Shell
    - [ ] bash
    - [x] zsh
    - [x] fish
- OS
    - [ ] Linux
    - [x] Mac OS X
    - [ ] Windows
    - [ ] Others:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the modified-file checkout picker by reusing a single, consistent list of modified files for both the empty-state check and the selection display.
  * Prevented cases where the candidates shown in the picker could differ from the availability logic used to decide whether files were selectable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->