### PR TITLE
fix: preserve LESS options in enter pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,14 @@ variables:
 | `FORGIT_BLAME_PAGER`      | `git config pager.blame` _or_ `$FORGIT_PAGER`    |
 | `FORGIT_IGNORE_PAGER`     | `bat -l gitignore --color always` _or_ `cat`     |
 | `FORGIT_ATTRIBUTES_PAGER` | `bat -l gitattributes --color always` _or_ `cat` |
-| `FORGIT_PREVIEW_PAGER`    | Normal pager resolution<sup>*</sup>              |
+| `FORGIT_ENTER_PAGER`      | `less -R -+F -+E`<sup>1</sup>                    |
+| `FORGIT_PREVIEW_PAGER`    | Normal pager resolution<sup>2</sup>              |
 
-<sup>*</sup> If your pager is a TUI program (e.g., `diffnav`, `tig`), fzf preview panes will be blank because they run
+<sup>1</sup> `FORGIT_ENTER_PAGER` controls the full-screen pager opened by the Enter key. Its default inherits options
+from `LESS`, enables safe ANSI color handling with `-R`, and disables `-F` and `-E` so the pager remains open for short
+output. Setting `FORGIT_ENTER_PAGER` replaces the default command.
+
+<sup>2</sup> If your pager is a TUI program (e.g., `diffnav`, `tig`), fzf preview panes will be blank because they run
 without a TTY. Set `FORGIT_PREVIEW_PAGER` to a non-interactive pager (e.g., `delta`) to fix this. When set, it
 overrides all other `FORGIT_*_PAGER` settings in fzf preview context.
 

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -171,7 +171,7 @@ _forgit_get_pager() {
         ignore) echo -n "${FORGIT_IGNORE_PAGER:-$(hash bat &>/dev/null && echo 'bat -l gitignore --color=always' || echo 'cat')}" ;;
         attributes) echo -n "${FORGIT_ATTRIBUTES_PAGER:-$(hash bat &>/dev/null && echo 'bat -l gitattributes --color=always' || echo 'cat')}" ;;
         blame) echo -n "${FORGIT_BLAME_PAGER:-$(git config pager.blame || _forgit_get_pager)}" ;;
-        enter) echo -n "${FORGIT_ENTER_PAGER:-"LESS='-r' less"}" ;;
+        enter) echo -n "${FORGIT_ENTER_PAGER:-"less -R -+F -+E"}" ;;
         *) echo "pager not found: $1" >&2 ;;
     esac
 }

--- a/tests/pager.test.sh
+++ b/tests/pager.test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function set_up_before_script() {
+    source bin/git-forgit
+}
+
+function less() {
+    printf 'LESS=%s\n' "$LESS"
+    printf 'ARGS=%s\n' "$*"
+}
+
+function test_enter_pager_preserves_less_and_disables_automatic_exit() {
+    local actual
+
+    actual=$(LESS="-F -E -X -S -N" _forgit_pager enter)
+
+    assert_contains "LESS=-F -E -X -S -N" "$actual"
+    assert_contains "ARGS=-R -+F -+E" "$actual"
+}


### PR DESCRIPTION
## Check list

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have added unit tests for my code
- [x] I have made corresponding changes to the documentation

## Description

Preserve user-defined `LESS` options when opening the full-screen Enter pager. Like Git, forgit now honors an existing `LESS` value rather than replacing it; the required color and stay-open behavior is expressed through command-line options.

Add regression coverage for inherited `LESS` options and document the default `FORGIT_ENTER_PAGER` behavior.

Fixes #538.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Test
- [x] Documentation change
- [ ] CI change

## Test environment

- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:

Additional verification: `lib/bashunit tests` (74 tests, 123 assertions), shfmt, Bash syntax check, rumdl, and ShellCheck 0.11.0 with the repository's pre-existing SC2218 findings excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `FORGIT_ENTER_PAGER` configuration for customizing the pager used when entering interactive views.
  - The default pager now preserves existing `LESS` settings while preventing automatic exit behavior.

- **Documentation**
  - Documented the new pager configuration option, its default value, and configuration behavior.

- **Tests**
  - Added coverage to verify pager environment preservation and interactive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->