### PR TITLE
feat: add option to disable auto creating branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,17 +371,19 @@ export FORGIT_LOG_FZF_OPTS='
 
 ### Other Options
 
-| Option                         | Description                                                                                                                    | Default                                       |
-|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| `FORGIT_LOG_FORMAT`            | git log format                                                                                                                 | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
-| `FORGIT_GLO_FORMAT`            | override log format for `glo` command                                                                                          | `$FORGIT_LOG_FORMAT`                          |
-| `FORGIT_LOG_GRAPH_ENABLE`     | enable log graph display                                                                                                       | `true`                                        |
-| `FORGIT_COPY_CMD`             | command for copying to clipboard                                                                                               | `pbcopy`                                      |
-| `FORGIT_PREVIEW_CONTEXT`       | lines of diff context in preview mode                                                                                          | 3                                             |
-| `FORGIT_FULLSCREEN_CONTEXT`    | lines of diff context in full-screen mode                                                                                      | 10                                            |
-| `FORGIT_DIR_VIEW`              | command used to preview directories                                                                                            | `tree` if available, otherwise `find`         |
-| `FORGIT_CLEAN_LIST_FILES_OPTS` | arguments passed to `git ls-files` together with `--others` to determine which files are shown when invoking `forgit clean`    |                                               |
-| `FORGIT_WORKTREE_ADD_DIR`      | directory where new worktrees are created                                                                                      | `<repo-root>/.wt`                             |
+| Option                                      | Description                                                                                                                      | Default                                       |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `FORGIT_LOG_FORMAT`                         | git log format                                                                                                                   | `%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset` |
+| `FORGIT_GLO_FORMAT`                         | override log format for `glo` command                                                                                            | `$FORGIT_LOG_FORMAT`                          |
+| `FORGIT_LOG_GRAPH_ENABLE`                   | enable log graph display                                                                                                         | `true`                                        |
+| `FORGIT_COPY_CMD`                           | command for copying to clipboard                                                                                                 | `pbcopy`                                      |
+| `FORGIT_PREVIEW_CONTEXT`                    | lines of diff context in preview mode                                                                                            | 3                                             |
+| `FORGIT_FULLSCREEN_CONTEXT`                 | lines of diff context in full-screen mode                                                                                        | 10                                            |
+| `FORGIT_DIR_VIEW`                           | command used to preview directories                                                                                              | `tree` if available, otherwise `find`         |
+| `FORGIT_CLEAN_LIST_FILES_OPTS`              | arguments passed to `git ls-files` together with `--others` to determine which files are shown when invoking `forgit clean`      |                                               |
+| `FORGIT_WORKTREE_ADD_DIR`                   | directory where new worktrees are created                                                                                        | `<repo-root>/.wt`                             |
+| `FORGIT_CHECKOUT_BRANCH_AUTO_CREATE_BRANCH` | prevents forgit from auto creating a new branch with `gcb <BRANCH_NAME>` when `<BRANCH_NAME>` does not exist when set to `false` |                                               |
+| `FORGIT_SWITCH_AUTO_CREATE_BRANCH`          | prevents forgit from auto creating a new branch with `gsw <BRANCH_NAME>` when `<BRANCH_NAME>` does not exist when set to `false` |                                               |
 
 ⌨ Keybindings
 ---------------

--- a/bin/git-forgit
+++ b/bin/git-forgit
@@ -1202,8 +1202,9 @@ _forgit_git_checkout_branch() {
 _forgit_checkout_branch() {
     _forgit_inside_work_tree || return 1
     # if called with arguments, check if branch exists, else create a new one
+    # this behavior can be disabled by setting FORGIT_CHECKOUT_BRANCH_AUTO_CREATE_BRANCH to false
     if [[ $# -ne 0 ]]; then
-        if [[ $* == "-" ]] || git show-branch "$@" &>/dev/null; then
+        if [[ $FORGIT_CHECKOUT_BRANCH_AUTO_CREATE_BRANCH == false ]] || [[ $* == "-" ]] || git show-branch "$@" &>/dev/null; then
             git switch "$@"
         else
             git switch -c "$@"
@@ -1248,8 +1249,9 @@ _forgit_git_switch_branch() {
 _forgit_switch_branch() {
     _forgit_inside_work_tree || return 1
     # if called with arguments, check if branch exists, else create a new one
+    # this behavior can be disabled by setting FORGIT_SWITCH_AUTO_CREATE_BRANCH to false
     if [[ $# -ne 0 ]]; then
-        if [[ $* == "-" ]] || git show-branch "$@" &>/dev/null; then
+        if [[ $FORGIT_SWITCH_AUTO_CREATE_BRANCH == false ]] || [[ $* == "-" ]] || git show-branch "$@" &>/dev/null; then
             git switch "$@"
         else
             git switch -c "$@"

--- a/tests/checkout-branch.test.sh
+++ b/tests/checkout-branch.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+function set_up_before_script() {
+    source bin/git-forgit
+
+    # Ignore global git config files
+    export GIT_CONFIG_SYSTEM=/dev/null
+    export GIT_CONFIG_GLOBAL=/dev/null
+
+    # Create a temporary git repository for testing
+    cd "$(bashunit::temp_dir)" || return 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git commit -q --allow-empty -m "initial commit"
+    git branch existing-branch
+}
+
+function test_checkout_branch_creates_branch_when_it_does_not_exist() {
+    _forgit_checkout_branch auto-created-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "auto-created-branch" "$(git branch --show-current)"
+}
+
+function test_checkout_branch_does_not_create_branch_when_auto_create_is_disabled() {
+    FORGIT_CHECKOUT_BRANCH_AUTO_CREATE_BRANCH=false
+    _forgit_checkout_branch not-created-branch &>/dev/null
+    assert_exit_code "128"
+    assert_not_same "not-created-branch" "$(git branch --show-current)"
+}
+
+function test_checkout_branch_switches_to_existing_branch() {
+    _forgit_checkout_branch existing-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "existing-branch" "$(git branch --show-current)"
+}
+
+function test_checkout_branch_switches_to_existing_branch_when_auto_create_is_disabled() {
+    FORGIT_CHECKOUT_BRANCH_AUTO_CREATE_BRANCH=false
+    _forgit_checkout_branch existing-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "existing-branch" "$(git branch --show-current)"
+}
+
+function test_checkout_branch_creates_branch_when_requested_when_auto_create_is_disabled() {
+    FORGIT_CHECKOUT_BRANCH_AUTO_CREATE_BRANCH=false
+    _forgit_checkout_branch -c explicitly-created-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "explicitly-created-branch" "$(git branch --show-current)"
+}

--- a/tests/switch-branch.test.sh
+++ b/tests/switch-branch.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+function set_up_before_script() {
+    source bin/git-forgit
+
+    # Ignore global git config files
+    export GIT_CONFIG_SYSTEM=/dev/null
+    export GIT_CONFIG_GLOBAL=/dev/null
+
+    # Create a temporary git repository for testing
+    cd "$(bashunit::temp_dir)" || return 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git commit -q --allow-empty -m "initial commit"
+    git branch existing-branch
+}
+
+function test_switch_branch_creates_branch_when_it_does_not_exist() {
+    _forgit_switch_branch auto-created-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "auto-created-branch" "$(git branch --show-current)"
+}
+
+function test_switch_branch_does_not_create_branch_when_auto_create_is_disabled() {
+    FORGIT_SWITCH_AUTO_CREATE_BRANCH=false
+    _forgit_switch_branch not-created-branch &>/dev/null
+    assert_exit_code "128"
+    assert_not_contains "not-created-branch" "$(git branch --list --format='%(refname:short)')"
+}
+
+function test_switch_branch_switches_to_existing_branch() {
+    FORGIT_SWITCH_AUTO_CREATE_BRANCH=false
+    _forgit_switch_branch existing-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "existing-branch" "$(git branch --show-current)"
+}
+
+function test_switch_branch_switches_to_existing_branch_when_auto_create_is_disabled() {
+    FORGIT_SWITCH_AUTO_CREATE_BRANCH=false
+    _forgit_switch_branch existing-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "existing-branch" "$(git branch --show-current)"
+}
+
+function test_switch_branch_creates_branch_when_requested_when_auto_create_is_disabled() {
+    FORGIT_SWITCH_AUTO_CREATE_BRANCH=false
+    _forgit_switch_branch -c explicitly-created-branch &>/dev/null
+    assert_exit_code "0"
+    assert_same "explicitly-created-branch" "$(git branch --show-current)"
+}


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have added unit tests for my code
- [X] I have made corresponding changes to the documentation

## Description

I personally don't like the automatic creation of branches that these commands provide and prefer to be explicit about creating new branches. This solves an issue I've been running into in the past, where I wanted to create a new branch with `gsw`, but switched to an existing one without noticing and based my work on an old branch by accident.
Adds `$FORGIT_SWITCH_AUTO_CREATE_BRANCH` and `$FORGIT_CHECKOUT_BRANCH_AUTO_CREATE_BRANCH` environment variables that can be set to `false` to prevent `checkout_branch <BRANCH_NAME>` and `switch_brach <BRANCH_NAME>` from creating new branches when they do not exist. With the environment variables set to `false`, new branches can still be created explicitly using `switch_branch -c <BRANCH_NAME>` and `<checkout_branch> -c <BRANCH_NAME>` respectively.

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change
- [ ] CI change

## Test environment

- Shell
    - [ ] bash
    - [X] zsh
    - [ ] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to disable automatic creation of missing branches during checkout and switch operations.
  * Existing branches continue to work normally, while the `-c` option can explicitly create a branch when needed.

* **Documentation**
  * Documented the new environment variables and their behavior in the README.

* **Tests**
  * Added coverage for automatic creation, disabled creation, existing branches, and explicit branch creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->