### PR TITLE
fix(fish): completions fail to load with fish >= 4.8.0

### DIFF
--- a/completions/git-forgit.fish
+++ b/completions/git-forgit.fish
@@ -20,8 +20,29 @@ function __fish_forgit_worktrees
     git worktree list --porcelain 2>/dev/null | string match -r '^worktree .+' | string replace 'worktree ' ''
 end
 
-# Load helper functions in git completion file
-not functions -q __fish_git && source $__fish_data_dir/completions/git.fish
+# Load git completion functions
+function __fish_forgit_load_git_completions
+    if functions -q __fish_git
+        return 0
+    end
+
+    # Fish >= 4.2.0 ships git completions in its binary
+    if set --local git_completions (status get-file completions/git.fish)
+        printf '%s\n' $git_completions | source
+        return 0
+    end
+
+    # Older fish versions ship completions in a file
+    set --local git_completions_file "$__fish_data_dir/completions/git.fish"
+    if test -f "$git_completions_file"
+        source "$git_completions_file"
+        return 0
+    end
+
+    return 1
+end
+
+__fish_forgit_load_git_completions || exit
 
 # No file completion by default
 complete -c git-forgit -x


### PR DESCRIPTION
## Check list

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have added unit tests for my code
- [ ] I have made corresponding changes to the documentation

## Description

Fish started shipping git completions in the binary with 4.2.0 and deprecated the old completion files with 4.8.0.

Update forgit’s fish completion loader to support both models:

* prefer `status get-file completions/git.fish` (binary-embedded completions)
* fall back to `$__fish_data_dir/completions/git.fish` (completion files)

Also refactors loading into a helper function to allow early returns and reduce nesting.

closes #548

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Test
- [ ] Documentation change
- [ ] CI change

## Test environment

- Shell
    - [ ] bash
    - [ ] zsh
    - [X] fish
- OS
    - [X] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Others:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git completion loading across supported Fish versions.
  - Added a fallback for environments where Git completions are not bundled with Fish.
  - Prevents further completion setup when Git completions cannot be loaded, avoiding incomplete or misleading command suggestions.
  - Preserves existing Git completion behavior when completions are already available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->